### PR TITLE
Fix runtimerequires.sh script

### DIFF
--- a/runtimerequires.sh
+++ b/runtimerequires.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-cat smt.spec | grep "^Requires" | awk '{print $2 }' | xargs
+cat package/smt.spec | grep "^Requires" | awk '{print $2 }' | xargs
 


### PR DESCRIPTION
smt.spec is located in the directory package.
