### PR TITLE
Udapte CLI.pm ID to ProductCatalogs

### DIFF
--- a/www/perl-lib/SMT/CLI.pm
+++ b/www/perl-lib/SMT/CLI.pm
@@ -1448,7 +1448,7 @@ sub removeCustomCatalog
     # delete existing catalogs with this id
 
     my $affected1 = $dbh->do(sprintf("DELETE from Catalogs where ID=%s", $dbh->quote($options{catalogid})));
-    my $affected2 = $dbh->do(sprintf("DELETE from ProductCatalogs where ID=%s", $dbh->quote($options{catalogid})));
+    my $affected2 = $dbh->do(sprintf("DELETE from ProductCatalogs where PRODUCTID=%s", $dbh->quote($options{catalogid})));
 
     $affected1=0 if($affected1 != 1);
 


### PR DESCRIPTION
Adding smt-setup-custom-repos result in DBD::mysql::db do failed: 
Unknown column 'ID' in 'where clause' at /usr/lib/perl5/vendor_perl/5.10.0/SMT/CLI.pm line 1451.
This is due to new smt 2.x has in the table ProductCatalogs no more ID Column, only PRODUCTID.
see https://github.com/SUSE/smt/blob/master/db/schemas/mysql/2.00/100-smt-tables.sql
Please change the ID here to PRODUCTID.
