### PR TITLE
upgrade from SMT11 does not preserve SCCcredentials permissions (bsc#…

### DIFF
--- a/config/smt-maintenance
+++ b/config/smt-maintenance
@@ -16,7 +16,10 @@ function test_cred_permissions {
     if [ -n $cred_file ]; then
         if ! su -s /bin/bash -c "/usr/bin/test -r $cred_file" -l smt; then
             logger 'Updating SCCcredentials permissions to allow smt read access'
-            /usr/bin/setfacl -m u:smt:r $cred_file
+            if ! /usr/bin/setfacl -m u:smt:r $cred_file 2>/dev/null; then
+                logger "ERROR: Cannot update ACL. Make sure 'smt' user has read access to ${cred_file}."
+                return 1
+            fi
         fi
     fi
     return 0

--- a/config/smt-maintenance
+++ b/config/smt-maintenance
@@ -14,14 +14,9 @@ exit_code=0
 function test_cred_permissions {
     cred_file="/etc/zypp/credentials.d/SCCcredentials"
     if [ -n $cred_file ]; then
-        su -s /bin/bash -c "if [ ! -r $cred_file ]; then
-                                logger \"Unable to read $cred_file: Permission denied.\";
-                                logger \"You need to grant read access for the user 'smt'\";
-                                logger \"Example: /usr/bin/setfacl -m u:smt:r $cred_file\";
-                                exit 1;
-                            fi" - smt
-        if [ "$?" != "0" ]; then
-            return 1
+        if ! su -s /bin/bash -c "/usr/bin/test -r $cred_file" -l smt; then
+            logger 'Updating SCCcredentials permissions to allow smt read access'
+            /usr/bin/setfacl -m u:smt:r $cred_file
         fi
     fi
     return 0


### PR DESCRIPTION
…943568)

- read permissions for smt is now checked and set each time smt-maintenance is
  run