### PR TITLE
Smt12 add suse symlink

### DIFF
--- a/package/smt.changes
+++ b/package/smt.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct  8 08:48:24 CEST 2015 - mc@suse.com
+
+- create a symlink to repo/SUSE when exporting to directory
+  (bsc#949361)
+
+-------------------------------------------------------------------
 Mon Oct  5 11:49:33 UTC 2015 - oholecek@suse.com
 
 - version 3.0.5

--- a/script/smt-mirror
+++ b/script/smt-mirror
@@ -505,6 +505,13 @@ if(!defined $dbreplfile)
     }
 }
 
+# bsc#949361
+if( $LocalBasePath && ! -d SMT::Utils::cleanPath($LocalBasePath, "SUSE") &&
+    -d SMT::Utils::cleanPath($LocalBasePath, "repo", "SUSE"))
+{
+    symlink("repo/SUSE", SMT::Utils::cleanPath($LocalBasePath, "SUSE"));
+}
+
 SMT::Utils::runHook("mirror_preunlock_hook");
 
 if(!SMT::Utils::unLock("smt-mirror"))


### PR DESCRIPTION
In disconnected more SUSE Manager or SMT try to mirror SUSE repos from the official path which is
parallel to repo/ directory.
But SMT mirror it into the repo/ directory to be able to support staging. 

This patch create a symlink SUSE -> repo/SUSE

@aaannz , @jsrain : please review this bugfix