### PR TITLE
- Implement registration sharing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ install:
 	ln -s smt-setup-custom-repos $(DESTDIR)/usr/sbin/smt-setup-custom-catalogs
 	install -m 644 www/perl-lib/NU/*.pm $(DESTDIR)/srv/www/perl-lib/NU/
 	install -m 644 www/perl-lib/SMT/Registration.pm $(DESTDIR)/srv/www/perl-lib/SMT/
+	install -m 644 www/perl-lib/SMT/RegistrationSharing.pm $(DESTDIR)$(PERLMODDIR)/SMT/
 	install -m 644 www/perl-lib/SMT/Support.pm $(DESTDIR)/srv/www/perl-lib/SMT/
 	install -m 644 www/perl-lib/SMT/Utils.pm $(DESTDIR)$(PERLMODDIR)/SMT/
 	install -m 644 www/perl-lib/SMT/NCCRegTools.pm $(DESTDIR)$(PERLMODDIR)/SMT/
@@ -136,6 +137,7 @@ install:
 	install -m 755 db/smt-db $(DESTDIR)/usr/lib/SMT/bin/
 	install -m 755 script/changeSMTUserPermissions.sh $(DESTDIR)/usr/lib/SMT/bin/
 	install -m 755 script/reschedule-sync.sh $(DESTDIR)/usr/lib/SMT/bin/
+	install -m 755 tests/SMT/shareRegistration.pl $(DESTDIR)/usr/lib/SMT/bin/
 	install -m 755 script/clientSetup4SMT.sh $(DESTDIR)/srv/www/htdocs/repo/tools/
 	install -m 644 www/repo/res-signingkeys.key $(DESTDIR)/srv/www/htdocs/repo/keys/
 	install -m 644 cron/novell.com-smt $(DESTDIR)/etc/smt.d/
@@ -225,6 +227,7 @@ dist: clean
 	@cp doc/README-SCC $(NAME)-$(VERSION)/doc/
 
 	@cp tests/*.pl $(NAME)-$(VERSION)/tests/
+	@cp tests/SMT/shareRegistration.pl $(NAME)-$(VERSION)/tests/SMT
 	@cp tests/SMT/Mirror/*.pl $(NAME)-$(VERSION)/tests/SMT/Mirror/
 	@cp -r tests/testdata/regdatatest/* $(NAME)-$(VERSION)/tests/testdata/regdatatest/
 	@cp script/* $(NAME)-$(VERSION)/script/

--- a/package/smt.changes
+++ b/package/smt.changes
@@ -1,4 +1,26 @@
 -------------------------------------------------------------------
+Fri Apr 15 11:49:34 EDT 2016 - rjschwei@suse.com
+
+- SMT HA functionality for Cloud setup
+  + Enable registration sharing between SMT servers that are configured
+    as sibling servers
+  + New configuration options
+    ~ cloudGuestVerify - enables a verification plugin to check if access
+                         should be granted
+    ~ acceptRegistrationSharing - set IP or DNS name indicating from
+                                  which server sharing requests should be
+                                  accepted
+    ~ shareRegistrations - set IP or DNS name indicating the servers that
+                           should receive shared registration requests
+    ~ siblingCertDir - location where the sibling certs may be stored
+  + Example implementation of verification code
+  + Support deletion of registrations on the sibling server(s) in
+    smt-delete-registration
+  + HA functionality is encapsulated in -ha sub-package
+  + Implement plugin mechanism to allow cloud specific functionality
+    to be maintained separately
+
+-------------------------------------------------------------------
 Wed Apr 13 12:29:16 CEST 2016 - mc@suse.de
 
 - Fix duplicate ProductCatalogs entries while NCC to SCC migration

--- a/package/smt.spec
+++ b/package/smt.spec
@@ -91,7 +91,6 @@ PreReq:         smt = %version
 This package contain the signing key for RES.
 
 
-
 Authors:
 --------
     Authors:
@@ -121,6 +120,42 @@ Authors:
         jdsn@suse.de
         locilka@suse.cz
 
+%package ha
+Summary:     SMT HA setup
+Group:       Productivity/Networking/Web/Proxy
+PreReq:      smt = %version
+Requires:    perl-File-Touch
+Requires:    perl-File-Slurp
+Requires:    perl-XML-LibXML
+
+%description ha
+This package extends the basic SMT functionality with registration sharing
+capabilities. This allows 2 or more SMT servers running at the same time to
+share the registrations they receive. The following smt.conf options are
+used.
+
+#
+# This string is used to verify that any sender trying to share a
+# registration is allowed to do so. Provide a comma separated list of
+# names or IP addresses.
+acceptRegistrationSharing=
+#
+# This string is used to set the host names and or IP addresses of sibling
+# SMT servers to which the registration data should be sent. For multiple
+# siblings provide a comma separated list.
+shareRegistrations=
+#
+# This string provides information for SSL verification of teh siblings.
+# Certificates for the siblings should reside in the given directory.
+# If not defined siblings are assumed to have the same CA as this server
+siblingCertDir=
+
+Authors:
+--------
+    rjschwei@suse.com
+
+
+ 
 %prep
 %setup -n %{name}-%{version}
 cp -p %{S:1} .
@@ -241,6 +276,7 @@ fi
 %config /etc/logrotate.d/smt
 /etc/init.d/smt
 /usr/sbin/rcsmt
+%exclude %{perl_vendorlib}/SMT/RegistrationSharing.pm
 %{perl_vendorlib}/SMT.pm
 %{perl_vendorlib}/SMT/*.pm
 %{perl_vendorlib}/SMT/Job/*.pm
@@ -256,9 +292,11 @@ fi
 %exclude /srv/www/perl-lib/SMT/Support.pm
 /usr/sbin/smt-*
 %exclude /usr/sbin/smt-support
+%exclude /usr/sbin/smt-sibling-sync
 /usr/sbin/smt
 /var/adm/fillup-templates/sysconfig.apache2-smt
 /usr/lib/SMT/bin/*
+%exclude /usr/lib/SMT/bin/shareRegistration.pl
 /srv/www/htdocs/repo/tools/*
 %{_datadir}/schemas/smt/*
 %doc %attr(644, root, root) %{_mandir}/man3/*
@@ -278,5 +316,11 @@ fi
 %config /etc/smt.d/smt_support.conf
 %dir %attr(775, smt, www)/var/spool/smt-support
 %doc %attr(644, root, root) %{_mandir}/man1/smt-support.1.gz
+
+%files ha
+%defattr(-,root,root)
+/usr/lib/SMT/bin/shareRegistration.pl
+%{perl_vendorlib}/SMT/RegistrationSharing.pm
+%{_sbindir}/smt-sibling-sync
 
 %changelog

--- a/script/smt-sibling-sync
+++ b/script/smt-sibling-sync
@@ -1,0 +1,93 @@
+#!/usr/bin/perl
+
+###############################################################################
+## Copyright (c) 2015 SUSE LLC
+###############################################################################
+
+use strict;
+use warnings;
+use Getopt::Long;
+use SMT::Utils;
+use SMT::RegistrationSharing;
+
+if(!SMT::Utils::dropPrivileges())
+{
+    print STDERR __("Unable to drop privileges. Abort!\n");
+    exit 1;
+}
+
+my $help  = 0;
+my $logfile = "/dev/null";
+
+my $optres = GetOptions ("logfile|L=s" => \$logfile,
+                         "help|h"      => \$help
+                        );
+
+if($help) {
+    print basename($0) . __(" [OPTIONS]\n");
+    print __("Sync this SMT server with its configured siblings\n");
+    print "\n";
+    print __("Options:\n");
+    print "  --logfile (-L) <file>  : " . __("Path to logfile")."\n";
+    exit 0;
+}
+
+my $log = SMT::Utils::openLog($logfile);
+
+my $dbh = SMT::Utils::db_connect();
+my $statement = 'SELECT GUID from Registration';
+my $guids = $dbh->selectcol_arrayref($statement);
+
+if (! $guids) {
+    print "This server has no registrations, nothing to do\n";
+    exit 0;
+}
+
+for my $guid (@{$guids}) {
+    SMT::RegistrationSharing::shareRegistration($guid, $log);
+}
+
+#
+# Manpage
+#
+
+=head1 NAME
+
+smt-sibling-sync
+
+=head1 SYNOPSIS
+
+smt-sibling-sync
+
+=head1 DESCRIPTION
+
+I<smt-sibling-sync> syncs all registered clients with the configured sibling SMT server(s). The sibling SMT server(s) are configured with the shareRegistrations configuration option.
+
+=head1 OPTIONS
+
+None
+
+=head1 AUTHORS and CONTRIBUTORS
+
+Robert Schweikert
+
+=head1 LICENSE
+
+Copyright (c) 2015 SUSE LLC
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 675 Mass
+Ave, Cambridge, MA 02139, USA.
+
+=cut
+
+

--- a/tests/SMT/shareRegistration.pl
+++ b/tests/SMT/shareRegistration.pl
@@ -1,0 +1,86 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+
+use Data::Dumper;
+use Config::IniFiles;
+use Getopt::Long;
+use SMT::Utils;
+use WWW::Curl::Easy;
+
+my $smtHost;
+my $config;
+GetOptions ('config=s' => \$config,
+            'host=s' => \$smtHost);
+
+if (! $smtHost && ! $config) {
+    my $msg = 'Must specify the target SMT server with --host or config '
+        . "file with --config.\n";
+    print $msg;
+    exit 1;
+}
+
+if ($config && ! -f $config) {
+    print "could not find configuration file '$config'\n";
+    exit 1;
+}
+
+my $regInfo = "<?xml version='1.0' encoding='UTF-8'?>"
+    . "<registrationData>"
+    . "<tableData table='Clients'>"
+    . "<entry comulmnName='NAMESPACE' value=''/>"
+    . "<entry comulmnName='HOSTNAME' value='smt-client'/>"
+    . "<entry comulmnName='TARGET' value='sle-11-x86_64'/>"
+    . "<entry comulmnName='GUID' value='03a8f41f176d4776aed0ea2263ea82c4'/>"
+    . "<entry comulmnName='SECRET' value='efaf1ed2f80a4548b4904dc5888f9958'/>"
+    . "<entry comulmnName='DESCRIPTION' value=''/>"
+    . "<entry comulmnName='REGTYPE' value='SR'/>"
+    . "<entry comulmnName='LASTCONTACT' value='2014-08-27 13:41:11'/>"
+    . "</tableData>"
+    . "<tableData table='Registration'>"
+    . "<entry comulmnName='REGDATE' value='2014-08-26 09:58:15'/>"
+    . "<entry comulmnName='NCCREGERROR' value='0'/>"
+    . "<entry comulmnName='NCCREGDATE' value=''/>"
+    . "<entry comulmnName='GUID' value='03a8f41f176d4776aed0ea2263ea82c4'/>"
+    . "<entry comulmnName='PRODUCTID' value='100550'/>"
+    . "</tableData>"
+    . "</registrationData>";
+
+my $shareRegDataTargets;
+my $certPath;
+
+if ($config) {
+    my $cfg = new Config::IniFiles( -file => $config );
+    $shareRegDataTargets = $cfg->val('LOCAL', 'shareRegistrations');
+    if (! $shareRegDataTargets) {
+        print "No registration sharing configured in '$config'\n";
+        exit 1;
+    }
+    $certPath = $cfg->val('LOCAL', 'siblingCertDir');
+}
+else {
+    $shareRegDataTargets = $smtHost;
+}
+
+my @smtSiblings = split /,/, $shareRegDataTargets;
+for my $smtServer (@smtSiblings) {
+    my $ua = SMT::Utils::createUserAgent();
+    if ($certPath) {
+        $ua->setopt(CURLOPT_CAPATH, $certPath);
+    }
+    my $url = "https://$smtServer/center/regsvc"
+                . '?command=shareregistration'
+                . '&lang=en-US&version=1.0';
+    my $response = $ua->post($url, Content=>$regInfo);
+
+    if (! $response->is_success) {
+        my $dd = Data::Dumper->new([ $response ]);
+        print $dd->Dump();
+        print "Test FAILED for host '$smtServer'\n";
+    }
+    else {
+        print "SUCCESS for host '$smtServer'\n";
+    }
+}
+
+

--- a/www/perl-lib/SMT/Client/exampleVerify.pm
+++ b/www/perl-lib/SMT/Client/exampleVerify.pm
@@ -13,7 +13,26 @@ sub verifyGuest {
     my $regroot = shift;
     # Insert code to connect to cloud framework and verify the guest
     # return 1 for successful verification, undef for verification failure
+    # $r -> the request, i.e an Apache request object
+    #       http://perl.apache.org/docs/2.0/api/Apache2/RequestRec.html
+    # $regroot ->  HASHREF containing information sent by the client.
     return 1;
+}
+
+sub verifySCCGuest {
+
+    my $self     = shift;
+    my $r        = shift;
+    my $clntData = shift;
+    my $result   = shift;
+    # Insert code to connect to cloud framework and verify the guest
+    # return the result HASHREF for successful verification, undef for
+    # verification failure
+    # $r -> the request, i.e an Apache request object
+    #       http://perl.apache.org/docs/2.0/api/Apache2/RequestRec.html
+    # $clntData -> data received from the client
+    # $result -> HASHREF of results of various previous operations
+    return $result;
 }
 
 1;

--- a/www/perl-lib/SMT/NCCRegTools.pm
+++ b/www/perl-lib/SMT/NCCRegTools.pm
@@ -105,12 +105,12 @@ sub new
     $self->{AUTHPASS} = $pass;
 
     my $regsharing = SMT::Utils::hasRegSharing();
-    if (! $regsharing) {
+    if (! defined $regsharing) {
         my $msg = 'Could not read SMT configuration file';
         printLog($self->{LOG}, $self->vblevel(), LOG_WARN, __($msg));
-        $regsharing = 'false';
+        $regsharing = 0;
     }
-    elsif ($regsharing eq 'true') {
+    elsif ($regsharing == 1) {
         eval
         {
             require 'SMT/RegistrationSharing.pm';
@@ -121,7 +121,7 @@ sub new
               . '"SMT/RegistrationSharing.pm"'
               . "\n$@";
             printLog($self->{LOG}, $self->vblevel(), LOG_ERROR, __($msg));
-            $regsharing = 'false';
+            $regsharing = 0;
         }
     }
     $self->{REGSHARING} = $regsharing;
@@ -547,7 +547,7 @@ sub NCCDeleteRegistration
         }
 
         $self->_deleteRegistrationLocal($guid);
-        if ($self->{REGSHARING} eq 'true')
+        if ($self->{REGSHARING})
         {
             SMT::RegistrationSharing::deleteSiblingRegistration(
                                                         $guid,

--- a/www/perl-lib/SMT/NCCRegTools.pm
+++ b/www/perl-lib/SMT/NCCRegTools.pm
@@ -103,8 +103,30 @@ sub new
     $self->{URI}      = $ruri;
     $self->{AUTHUSER} = $user;
     $self->{AUTHPASS} = $pass;
-    bless($self);
 
+    my $regsharing = SMT::Utils::hasRegSharing();
+    if (! $regsharing) {
+        my $msg = 'Could not read SMT configuration file';
+        printLog($self->{LOG}, $self->vblevel(), LOG_WARN, __($msg));
+        $regsharing = 'false';
+    }
+    elsif ($regsharing eq 'true') {
+        eval
+        {
+            require 'SMT/RegistrationSharing.pm';
+        };
+        if ($@)
+        {
+            my $msg = 'Failed to load registration sharing module '
+              . '"SMT/RegistrationSharing.pm"'
+              . "\n$@";
+            printLog($self->{LOG}, $self->vblevel(), LOG_ERROR, __($msg));
+            $regsharing = 'false';
+        }
+    }
+    $self->{REGSHARING} = $regsharing;
+
+    bless($self);
     return $self;
 }
 
@@ -525,6 +547,13 @@ sub NCCDeleteRegistration
         }
 
         $self->_deleteRegistrationLocal($guid);
+        if ($self->{REGSHARING} eq 'true')
+        {
+            SMT::RegistrationSharing::deleteSiblingRegistration(
+                                                        $guid,
+                                                        $self->{LOG}
+            );
+        }
 
         if(!(exists $result->[0] && defined $result->[0] && $result->[0] eq $guid))
         {

--- a/www/perl-lib/SMT/Registration.pm
+++ b/www/perl-lib/SMT/Registration.pm
@@ -6,7 +6,7 @@ use warnings;
 use APR::Brigade ();
 use APR::Bucket ();
 use Apache2::Filter ();
-
+use Apache2::Log;
 use Apache2::RequestRec ();
 use Apache2::RequestIO ();
 
@@ -22,6 +22,8 @@ use DBI;
 use XML::Writer;
 use XML::Parser;
 use Date::Parse;
+
+my $REGSHARING;
 
 sub handler {
     my $r = shift;
@@ -51,6 +53,27 @@ sub handler {
         $r->log_error("protocol version '".$hargs->{'version'}."' not implemented");
         return SMT::Utils::http_fail($r, 400, "Invalid protocol version.");
     }
+
+    # check if registration sharing is enabled and load module if it is
+    if (SMT::Utils::hasRegSharing($r) && ! $REGSHARING) {
+        eval
+        {
+            require 'SMT/RegistrationSharing.pm';
+        };
+        if ($@)
+        {
+            my $msg = 'Failed to load registration sharing module '
+              . '"SMT/RegistrationSharing.pm"'
+              . "\n$@";
+            $r->log_error($msg);
+            $msg = 'Internal Server Error. Please contact your '
+              . 'administrator.';
+            return SMT::Utils::http_fail($r, 500, $msg);
+        }
+        # Plugin successfully loaded
+        $REGSHARING = 1;
+    }
+
     $r->log->info("Registration called with command: ".$hargs->{command});
 
     if(exists $hargs->{command} && defined $hargs->{command})
@@ -66,6 +89,28 @@ sub handler {
         elsif($hargs->{command} eq "listparams")
         {
             SMT::Registration::listparams($r, $hargs);
+        }
+        elsif($hargs->{command} eq "shareregistration")
+        {
+            if (! $REGSHARING) {
+                my $msg = "Registration sharing is not configured\n";
+                $r->log_error($msg);
+                $msg = 'Internal Server Error. Please contact your '
+                    . 'administrator.';
+                return http_fail($r, 500, $msg);
+            }
+            SMT::RegistrationSharing::addSharedRegistration($r, $hargs);
+        }
+        elsif($hargs->{command} eq "deltesharedregistration")
+        {
+            if (! $REGSHARING) {
+                my $msg = "Registration sharing is not configured\n";
+                $r->log_error($msg);
+                $msg = 'Internal Server Error. Please contact your '
+                    . 'administrator.';
+                return http_fail($r, 500, $msg);
+            }
+            SMT::RegistrationSharing::deleteSharedRegistration($r, $hargs);
         }
         else
         {
@@ -256,6 +301,12 @@ sub register
     }
     $dbh->disconnect();
 
+    if ($REGSHARING) {
+        # share the registration
+        SMT::RegistrationSharing::shareRegistration(
+                                               $regroot->{register}->{guid});
+    }
+
     return;
 }
 
@@ -344,6 +395,7 @@ sub listparams
 
     return;
 }
+
 
 ###############################################################################
 
@@ -1194,8 +1246,6 @@ sub findColumnsForProducts
 ###############################################################################
 ### XML::Parser Handler
 ###############################################################################
-
-
 sub prod_handle_start_tag
 {
     my $data = shift;

--- a/www/perl-lib/SMT/RegistrationSharing.pm
+++ b/www/perl-lib/SMT/RegistrationSharing.pm
@@ -1,0 +1,567 @@
+package SMT::RegistrationSharing;
+
+use strict;
+use warnings;
+
+use Apache2::Log;
+use Apache2::RequestRec ();
+use Apache2::ServerUtil ();
+use DBI qw(:sql_types);
+use File::Slurp;
+use File::Temp;
+use File::Touch;
+use SMT::Utils;
+use WWW::Curl::Easy;
+use XML::LibXML;
+#
+# called from handler in Registration module if registration is shared
+# from another SMT server
+# command=shareregistration argument given
+sub addSharedRegistration
+{
+    my $r     = shift;
+    my $hargs = shift;
+
+    my $apache = Apache2::ServerUtil->server;
+    my $acceptRequest = _verifySenderAllowed($r);
+    if ($acceptRequest != 1) {
+        return $acceptRequest;
+    }
+    # Process the registration request
+    my $regData = SMT::Utils::read_post($r);
+    my $regXML = _getXMLFromPostData($regData);
+    if (! $regXML)
+    {
+        my $msg = "Received invalid data:\n$@\n";
+        $apache->log_error($msg);
+        $r->log_error($msg);
+        return SMT::Utils::http_fail($r, 400, $msg);
+
+    }
+    my $dbh = SMT::Utils::db_connect();
+    my @tableEntries = $regXML->getElementsByTagName('tableData');
+    my $guid = _getGUIDfromTableEntry($tableEntries[0]);
+    if (SMT::Utils::lookupClientByGUID($dbh, $guid)) {
+        $dbh->disconnect();
+        $apache->log->info("Already have entry for '$guid' nothing to do");
+        return;
+    }
+    for my $entry (@tableEntries) {
+        $guid = _getGUIDfromTableEntry($entry);
+        my $statement = _createInsertSQLfromXML($r, $dbh, $entry);
+        if (! $statement) {
+            $dbh->disconnect();
+            my $msg = 'Could not generate SQL statement to insert '
+                . 'registration';
+            $r->log_error($msg);
+            return SMT::Utils::http_fail($r, 400, $msg);
+        }
+        eval {
+            $dbh->do($statement)
+        };
+        if ($@) {
+            $dbh->disconnect();
+            $r->log_error('Unable to insert registration into SMT database');
+            my $msg = 'Registration insert failed:\n'
+                . "STATEMENT: $statement\n"
+                . "Error: $@";
+            $apache->log_error($msg);
+            return SMT::Utils::http_fail($r, 400, $msg);
+        }
+    }
+    $dbh->disconnect();
+    return;
+}
+
+#
+# called from handler in Registration module if registration is shared
+# from another SMT server
+# command=deltesharedregistration argument given
+sub deleteSharedRegistration
+{
+    my $r     = shift;
+    my $hargs = shift;
+
+    my $apache = Apache2::ServerUtil->server;
+    my $acceptRequest = _verifySenderAllowed($r);
+    if ($acceptRequest != 1) {
+        return $acceptRequest;
+    }
+    # Process the delete request
+    my $guidData = SMT::Utils::read_post($r);
+    my $delXML = _getXMLFromPostData($guidData);
+    if (! $delXML)
+    {
+        my $msg = "Received invalid data:\n$@\n";
+        $apache->log_error($msg);
+        $r->log_error($msg);
+        return SMT::Utils::http_fail($r, 400, $msg);
+    }
+    my @guids = $delXML->getElementsByTagName('guid');
+    # There is only one guid element in the XML
+    my $guid = $guids[0]->textContent();
+    if (! $guid)
+    {
+        my $msg = 'No GUID received for deletion';
+        $r->log_error($msg);
+        return SMT::Utils::http_fail($r, 400, $msg);
+    }
+    my $dbh = SMT::Utils::db_connect();
+    my $found = 0;
+    my $where = sprintf("GUID = %s", $dbh->quote( $guid ) );
+    my $statement = "DELETE FROM Registration where ".$where;
+    my $res = $dbh->do($statement);
+    if ( $res > 0)
+    {
+        $found = 1;
+    }
+    $statement = "DELETE FROM Clients where ".$where;
+    $res = $dbh->do($statement);
+    $statement = "DELETE FROM MachineData where ".$where;
+    $res = $dbh->do($statement);
+    $dbh->disconnect();
+
+    if(! $found)
+    {
+        $apache->log->info("No registration with $guid found.");
+    }
+
+    return;
+}
+
+#
+# called from NCCRegTools::NCCDeleteRegistration if registration is shared
+# with another SMT server
+#
+sub deleteSiblingRegistration
+{
+    my $regGUID = shift;
+    my $logfile = shift;
+    my $log = SMT::Utils::openLog($logfile);
+    my $cfg;
+    eval
+    {
+        $cfg = SMT::Utils::getSMTConfig();
+    };
+    if($@ || !defined $cfg)
+    {
+        my $msg = 'Cannot read the SMT configuration file: '.$@;
+        print $log $msg;
+        return;
+    }
+    my $shareRegDataTargets = $cfg->val('LOCAL', 'shareRegistrations');
+    if (! $shareRegDataTargets) {
+        return 1;
+    }
+    my $guidXML = '<?xml version="1.0" encoding="UTF-8"?>'
+        . '<deleteRegistrationData>'
+        . '<guid>'
+        . $regGUID
+        . '</guid>'
+        . '</deleteRegistrationData>';
+    # SSL handling
+    my $certPath = $cfg->val('LOCAL', 'siblingCertDir');
+    # Send the registration data to the configured SMT siblings
+    my @smtSiblings = split /,/, $shareRegDataTargets;
+    for my $smtServer (@smtSiblings) {
+        my $ua = SMT::Utils::createUserAgent();
+        if ($certPath) {
+            $ua->setopt(CURLOPT_CAPATH, $certPath);
+        }
+        my $url = "https://$smtServer/center/regsvc"
+            . '?command=deltesharedregistration'
+            . '&lang=en-US&version=1.0';
+        my $response = $ua->post($url, Content=>$guidXML);
+        if (! $response->is_success ) {
+            my $msg = $response->message;
+            my $details = $response->content;
+            my $guidMsg = "Could not delete shared registration for $regGUID";
+            my $responseMsg = "Response: $msg";
+            my $detailsMsg = "Response: $details";
+            print $log $guidMsg . "\n";
+            print $log $responseMsg . "\n";
+            print $log $detailsMsg . "\n";
+        }
+    }
+    return;
+}
+
+#
+# called from register in Registration module if registration is shared
+# with another SMT server. The log argument is an indicator if the
+# registration sharing is triggered from a command line tool.
+#
+sub shareRegistration
+{
+    my $regGUID = shift;
+    my $log     = shift;
+    my $apache;
+    if (! $log) {
+        $apache = Apache2::ServerUtil->server;
+    }
+    # Get the configuration
+    my $cfg;
+    eval
+    {
+        $cfg = SMT::Utils::getSMTConfig();
+    };
+    if($@ || !defined $cfg)
+    {
+        my $msg = 'Cannot read the SMT configuration file: '.$@;
+        if ($log) {
+            print $log $msg;
+        } else {
+            $apache->log_error($msg);
+        }
+        return;
+    }
+    my $shareRegDataTargets = $cfg->val('LOCAL', 'shareRegistrations');
+    if (! $shareRegDataTargets) {
+        return 1;
+    }
+    my $dbh = SMT::Utils::db_connect();
+    # Setup the registration data as an XML string
+    my @tableData = ('Clients', 'Registration');
+    my $regXML = '<?xml version="1.0" encoding="UTF-8"?>'
+        . '<registrationData>';
+    # Get the registration data
+    for my $table (@tableData) {
+        my $statement = sprintf("SELECT * from %s where GUID=%s",
+                                $table,
+                                $dbh->quote($regGUID));
+        my $regData = $dbh->selectrow_hashref($statement);
+        if (! $regData) {
+            next;
+        }
+        my $skip;
+        if ($table eq 'Clients') {
+            my @skipColumn = ('ID');
+            $skip = \@skipColumn;
+        }
+        $regXML .= "<tableData table='$table'>"
+            . _getXMLFromRowData($regData, $skip)
+            . '</tableData>';
+    }
+    $regXML .= '</registrationData>';
+
+    # Send the registration data to the configured SMT siblings
+    if ( $regXML =~ /GUID/) {
+        my @smtSiblings = split /,/, $shareRegDataTargets;
+        for my $smtServer (@smtSiblings) {
+            my $url = "https://$smtServer/center/regsvc"
+                . '?command=shareregistration'
+                . '&lang=en-US&version=1.0';
+            my $response = _sendData($url, $regXML, $log);
+            if (! $response ) {
+                return;
+            }
+            if (! $response->is_success ) {
+                my $msg = $response->message;
+                my $details = $response->content;
+                my $guidMsg = "Could not share registration for $regGUID";
+                my $responseMsg = "Response: $msg";
+                my $detailsMsg = "Response: $details";
+                if ($log) {
+                    print $log $guidMsg . "\n";
+                    print $log $responseMsg . "\n";
+                    print $log $detailsMsg . "\n";
+                } else {
+                    $apache->warn($guidMsg);
+                    $apache->warn($responseMsg);
+                    $apache->warn($detailsMsg);
+                    _logShareRecord($smtServer,$url,$regXML);
+                }
+
+            } else {
+                _sharePreviousRegistrations($smtServer, $log);
+            }
+        }
+    }
+    $dbh->disconnect();
+    return;
+}
+
+#
+# Private
+#
+#
+# Generate the SQL statement to insert the registration that is being shared
+# into the DB
+#
+sub _createInsertSQLfromXML
+{
+    my $r       = shift;
+    my $dbh     = shift;
+    my $element = shift;
+    my $tableName = $element->getAttribute('table');
+    if (! $tableName) {
+        $dbh->disconnect();
+        my $xml = $element->textContent;
+        my $msg = "Could not determine table name for insertion from XML\n"
+            . $xml;
+        $r->log_error($msg);
+        return SMT::Utils::http_fail($r, 400, $msg);
+    }
+    my $sql = "INSERT into $tableName (";
+    my $vals = 'VALUES (';
+    for my $entry ($element->getElementsByTagName('entry')) {
+        $sql .= $entry->getAttribute('comulmnName')
+            . ', ';
+        my $val = $dbh->quote($entry->getAttribute('value'));
+        $vals .= "$val"
+            . ', ';
+    }
+    chop $sql; # remove trailing space
+    chop $sql; # remove trailing comma
+    chop $vals; # remove trailing space
+    chop $vals; # remove trailing comma
+
+    $sql .= ') ' . $vals . ')';
+
+    return $sql;
+}
+
+#
+# Get the Global ID for the given DB entry
+#
+sub _getGUIDfromTableEntry
+{
+    my $tableXML = shift;
+    for my $entry ($tableXML->getElementsByTagName('entry')) {
+        if ($entry->getAttribute('comulmnName') eq 'GUID') {
+            return $entry->getAttribute('value');
+        }
+    }
+    return;
+}
+
+#
+# Process the received data and turn it into an XML object
+#
+sub _getXMLFromPostData
+{
+    my $postData = shift;
+    my $xml;
+    my $parser = XML::LibXML->new();
+    eval {
+        # load_xml not available on SLES 11 SP3 due to version of
+        # LibXML and underlying libxml2
+        #$xm = XML::LibXML->load_xml(string => $postData);
+        my $POSTDATAFL = File::Temp->new(SUFFIX=>'.txt');
+        $POSTDATAFL->write($postData);
+        $POSTDATAFL->flush();
+        seek $POSTDATAFL, 0,0;
+        $xml = $parser->parse_fh($POSTDATAFL);
+    };
+
+    if ($@) {
+        return;
+    }
+    return $xml;
+}
+
+#
+# Turn DB data into XML format
+#
+sub _getXMLFromRowData
+{
+    my $rowData     = shift;
+    my $skipEntries = shift;
+    my %skip = map { ($_ => 1) } @{$skipEntries};
+    my %data = %{$rowData};
+    my @entries = keys %data;
+    my $xml = '';
+    for my $entry (@entries) {
+        if ($skip{$entry}) {
+            next;
+        }
+        if ($data{$entry}) {
+            $xml .= "<entry comulmnName='$entry' value='"
+                . $data{$entry}
+                . "'/>";
+        }
+    }
+    return $xml;
+}
+
+#
+# log a record to be shared such that it can be replayed once the
+# sibling server is back online
+#
+sub _logShareRecord{
+    my $logFileName = shift;
+    my $url         = shift;
+    my $regXML      = shift;
+    my $apache = Apache2::ServerUtil->server;
+
+    if (! -d '/var/lib/wwwrun/smt') {
+        my $status = mkdir '/var/lib/wwwrun/smt';
+        if (! $status) {
+            my $msg = 'Could not create "/var/lib/wwwrun/smt" to log failed '
+                . 'shared registration record.';
+            $apache->warn($msg);
+            return;
+        }
+    }
+    my $log = "/var/lib/wwwrun/smt/$logFileName";
+    my $lockFile = $log . '.lock';
+    while (-e $lockFile) {
+        sleep 1;
+    }
+    touch($lockFile);
+    my $status = open my $LOGFILE, '>>', $log;
+    if (! $status) {
+        my $msg = "Could not open log '$logFileName' for writing";
+        $apache->warn($msg);
+        my $errMsg = 'Could not create record in replay file. '
+            . 'The following must be added manually to the '
+            . 'configured sibling servers:'
+            . "\n$regXML";
+        $apache->error($errMsg);
+        unlink $lockFile;
+        return;
+    }
+    print $LOGFILE "$url";
+    print $LOGFILE '+++'; # Arbitrary separator used on playback
+    print $LOGFILE "$regXML\n";
+    close $LOGFILE;
+    unlink $lockFile;
+    return 1;
+}
+
+#
+# Send given data to the given url. The log argument is an indicator if the
+# registration sharing is triggered from a command line tool.
+#
+sub _sendData{
+    my $url  = shift;
+    my $data = shift;
+    my $log  = shift;
+
+    my $apache;
+    if (! $log) {
+        $apache = Apache2::ServerUtil->server;
+    }
+    # Get the configuration
+    my $cfg;
+    eval
+    {
+        $cfg = SMT::Utils::getSMTConfig();
+    };
+    if($@ || !defined $cfg)
+    {
+        my $msg = 'Cannot read the SMT configuration file: '.$@
+            . "\nUnable to read cert data for ssl handling.";
+        if ($log) {
+            print $log $msg;
+        } else {
+            $apache->log_error($msg);
+        }
+        return;
+    }
+
+    my $certPath = $cfg->val('LOCAL', 'siblingCertDir');
+    my $ua = SMT::Utils::createUserAgent();
+    if ($certPath) {
+        $ua->setopt(CURLOPT_CAPATH, $certPath);
+    }
+    return $ua->post($url, Content=>$data);
+}
+
+#
+# Share registrations that may have been logged due to a sibling server
+# beeing unreachable at one time.  The log argument is an indicator if the
+# registration sharing is triggered from a command line tool.
+#
+sub _sharePreviousRegistrations{
+    my $logFileName = shift;
+    my $log         = shift;
+
+    if (! -d '/var/lib/wwwrun/smt') {
+        return;
+    }
+
+    my $replayLog = "/var/lib/wwwrun/smt/$logFileName";
+    if (! -e $replayLog) {
+        return;
+    }
+
+    if ($log) {
+        unlink $replayLog;
+        return;
+    }
+
+    my $lockFile = $replayLog . '.lock';
+    while (-e $lockFile) {
+        sleep 1;
+    }
+    touch($lockFile);
+
+    my @undeliverdRecords;
+    my @records = File::Slurp::read_file($replayLog);
+    for my $record (@records) {
+        (my $url, my $regXML) = split /\+\+\+/, $record;
+        my $response = _sendData($url, $regXML, $log);
+        if (! $response) {
+            return;
+        }
+        if (! $response->is_success ) {
+            push @undeliverdRecords, $record;
+        }
+    }
+    unlink $lockFile;
+    unlink $replayLog;
+    if (@undeliverdRecords) {
+        for my $record (@undeliverdRecords) {
+            (my $url, my $regXML) = split /\+\+\+/, $record;
+            _logShareRecord($logFileName,$url,$regXML);
+        }
+    }
+}
+
+#
+# Verify that it is OK to accept the request
+#
+sub _verifySenderAllowed
+{
+    my $r = shift;
+
+    my $apache = Apache2::ServerUtil->server;
+    my $senderName = $r->hostname();
+    my $senderIP = $r->connection()->remote_ip();
+    my $msg = 'Received shared registration request from '
+        . $senderName
+        . ':'
+        . $senderIP;
+    $apache->log->info($msg);
+
+    # Verify that it is OK to accept the registration from this host
+    my $cfg;
+    eval
+    {
+        $cfg = SMT::Utils::getSMTConfig();
+    };
+    if($@ || !defined $cfg)
+    {
+        $r->log_error("Cannot read the SMT configuration file: ".$@);
+        return SMT::Utils::http_fail($r, 500,
+           "SMT server is missconfigured. Please contact your administrator.");
+    }
+    my $allowedSenders = $cfg->val('LOCAL', 'acceptRegistrationSharing');
+    my %acceptedProviders;
+    if ($allowedSenders) {
+        %acceptedProviders = map { ($_ => 1) } split /,/, $allowedSenders;
+    }
+
+    if ((! $acceptedProviders{$senderName})
+        && (! $acceptedProviders{$senderIP})) {
+        $msg = "Registration data not accepted, host $senderIP, not listed "
+            . 'as "acceptRegistrationSharing" provider in config file.';
+        $r->log_error($msg);
+        return SMT::Utils::http_fail($r, 403, $msg);
+    }
+
+    return 1;
+}
+
+1;

--- a/www/perl-lib/SMT/Rest/Base.pm
+++ b/www/perl-lib/SMT/Rest/Base.pm
@@ -56,6 +56,24 @@ sub new
                 '_cfg' => $cfg,
                 '_usr' => $r->user
     };
+
+    if (SMT::Utils::hasRegSharing($r) && ! $self->{regsharing} ) {
+        eval
+        {
+            require 'SMT/RegistrationSharing.pm';
+            #require SMT::RegistrationSharing;
+        };
+        if ($@)
+        {
+            my $msg = 'Failed to load registration sharing module '
+                . '"SMT/RegistrationSharing.pm"'
+                . "\n$@";
+            $r->log_error($msg);
+        }
+        # Plugin successfully loaded
+        $self->{regsharing} = 1;
+    }
+
     bless $self, $class;
     return $self;
 }

--- a/www/perl-lib/SMT/Rest/SCCAPIv1.pm
+++ b/www/perl-lib/SMT/Rest/SCCAPIv1.pm
@@ -10,7 +10,8 @@ use JSON;
 
 use SMT::Utils;
 use SMT::Client;
-use SMT;
+use SMT::Registration;
+
 
 sub new
 {

--- a/www/perl-lib/SMT/Rest/SCCAPIv1.pm
+++ b/www/perl-lib/SMT/Rest/SCCAPIv1.pm
@@ -10,8 +10,7 @@ use JSON;
 
 use SMT::Utils;
 use SMT::Client;
-use SMT::Registration;
-
+use SMT;
 
 sub new
 {
@@ -355,7 +354,6 @@ sub products
         }
     }
 
-
     #
     # lookup the Clients target
     #
@@ -602,6 +600,13 @@ sub announce
     {
         $self->request()->log_error(sprintf("SMT Registration error: Could not create initial patchstatus reporting job for client with guid: %s  ",
                                             $result->{login} )  );
+    }
+
+    #
+    # share the registration
+    #
+    if ($self->{regsharing}) {
+        SMT::RegistrationSharing::shareRegistration($result->{login});
     }
 
     return (Apache2::Const::OK, $result);

--- a/www/perl-lib/SMT/SCCSync.pm
+++ b/www/perl-lib/SMT/SCCSync.pm
@@ -162,7 +162,7 @@ sub new
                                    );
 
     my $regsharing = SMT::Utils::hasRegSharing();
-    if ($regsharing == -1) {
+    if (! defined $regsharing) {
         my $msg = 'Could not read SMT configuration file';
         printLog($self->{LOG}, $self->vblevel(), LOG_WARN, __($msg));
         $regsharing = 0;

--- a/www/perl-lib/SMT/SCCSync.pm
+++ b/www/perl-lib/SMT/SCCSync.pm
@@ -160,6 +160,28 @@ sub new
                                     authpass => $self->{AUTHPASS},
                                     ident => $self->{SMTGUID}
                                    );
+
+    my $regsharing = SMT::Utils::hasRegSharing();
+    if ($regsharing == -1) {
+        my $msg = 'Could not read SMT configuration file';
+        printLog($self->{LOG}, $self->vblevel(), LOG_WARN, __($msg));
+        $regsharing = 0;
+    }
+    if ($regsharing && ! $self->{REGSHARING}) {
+        eval
+        {
+            require 'SMT/RegistrationSharing.pm';
+            $self->{REGSHARING} = 1;
+        };
+        if ($@)
+        {
+            my $msg = 'Failed to load registration sharing module '
+              . '"SMT/RegistrationSharing.pm"'
+              . "\n$@";
+            printLog($self->{LOG}, $self->vblevel(), LOG_ERROR, __($msg));
+        }
+    }
+
     bless($self);
 
     return $self;
@@ -527,6 +549,13 @@ sub delete_systems
                     $self->{DBH}->quote($guid)));
 
         $self->_deleteRegistrationLocal($guid);
+        if ($self->{REGSHARING})
+        {
+            SMT::RegistrationSharing::deleteSiblingRegistration(
+                                                        $guid,
+                                                        $self->{LOG}
+            );
+        }
         if(!($data->[0] && $data->[0] eq $guid))
         {
             # this GUID was never registered at NCC

--- a/www/perl-lib/SMT/Utils.pm
+++ b/www/perl-lib/SMT/Utils.pm
@@ -148,14 +148,14 @@ sub hasRegSharing
         };
         if($@ || !defined $cfg)
         {
-            if (! $r)
+            if ($r)
             {
-                return;
+                $r->log_error("Cannot read the SMT configuration file: ".$@);
+                my $msg = 'SMT server is missconfigured. Please contact your '
+                  . 'administrator.';
+                http_fail($r, 500, $msg);
             }
-            $r->log_error("Cannot read the SMT configuration file: ".$@);
-            my $msg = 'SMT server is missconfigured. Please contact your '
-                . 'administrator.';
-            return http_fail($r, 500, $msg);
+            return;
         }
         my $allowedSenders = $cfg->val('LOCAL', 'acceptRegistrationSharing');
         my $shareRegDataTargets = $cfg->val('LOCAL', 'shareRegistrations');

--- a/www/perl-lib/SMT/Utils.pm
+++ b/www/perl-lib/SMT/Utils.pm
@@ -150,7 +150,7 @@ sub hasRegSharing
         {
             if (! $r)
             {
-                return -1;
+                return;
             }
             $r->log_error("Cannot read the SMT configuration file: ".$@);
             my $msg = 'SMT server is missconfigured. Please contact your '


### PR DESCRIPTION
  + Registration sharing allows two completely independently configured
    SMT servers to be configured as sibling servers. The sibling servers
    share registration information effectively creating an redundant setup.
    Code that can be implemented in the client can detect if the SMT server
    that it registered to is available, if not it can fail over to the sibling
    server and get access to the repositories with the same registration
    credentials.