### PR TITLE
- Implement registration sharing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ install:
 	ln -s smt-setup-custom-repos $(DESTDIR)/usr/sbin/smt-setup-custom-catalogs
 	install -m 644 www/perl-lib/NU/*.pm $(DESTDIR)/srv/www/perl-lib/NU/
 	install -m 644 www/perl-lib/SMT/Registration.pm $(DESTDIR)/srv/www/perl-lib/SMT/
+	install -m 644 www/perl-lib/SMT/RegistrationSharing.pm $(DESTDIR)$(PERLMODDIR)/SMT/
 	install -m 644 www/perl-lib/SMT/Support.pm $(DESTDIR)/srv/www/perl-lib/SMT/
 	install -m 644 www/perl-lib/SMT/Utils.pm $(DESTDIR)$(PERLMODDIR)/SMT/
 	install -m 644 www/perl-lib/SMT/Mirror/*.pm /$(DESTDIR)$(PERLMODDIR)/SMT/Mirror/
@@ -94,6 +95,7 @@ install:
 	install -m 755 db/smt-schema-upgrade $(DESTDIR)/usr/bin/
 	install -m 755 script/changeSMTUserPermissions.sh $(DESTDIR)/usr/lib/SMT/bin/
 	install -m 755 script/reschedule-sync.sh $(DESTDIR)/usr/lib/SMT/bin/
+	install -m 755 tests/SMT/shareRegistration.pl $(DESTDIR)/usr/lib/SMT/bin/
 	install -m 755 script/clientSetup4SMT.sh $(DESTDIR)/srv/www/htdocs/repo/tools/
 	install -m 644 www/repo/res-signingkeys.key $(DESTDIR)/srv/www/htdocs/repo/keys/
 	install -m 644 cron/novell.com-smt $(DESTDIR)/etc/cron.d/
@@ -187,6 +189,7 @@ dist: clean
 	@cp doc/README-SCC $(NAME)-$(VERSION)/doc/
 
 	@cp tests/*.pl $(NAME)-$(VERSION)/tests/
+	@cp tests/SMT/shareRegistration.pl $(NAME)-$(VERSION)/tests/SMT
 	@cp tests/SMT/Mirror/*.pl $(NAME)-$(VERSION)/tests/SMT/Mirror/
 	@cp -r tests/testdata/regdatatest/* $(NAME)-$(VERSION)/tests/testdata/regdatatest/
 	@cp script/* $(NAME)-$(VERSION)/script/

--- a/package/smt.changes
+++ b/package/smt.changes
@@ -1,4 +1,26 @@
 -------------------------------------------------------------------
+Sat Apr 30 08:05:19 EDT 2016 - rjschwei@suse.com
+
+- SMT HA functionality for Cloud setup
+  + Enable registration sharing between SMT servers that are configured
+    as sibling servers
+  + New configuration options
+    ~ cloudGuestVerify - enables a verification plugin to check if access
+                         should be granted
+    ~ acceptRegistrationSharing - set IP or DNS name indicating from
+                                  which server sharing requests should be
+                                  accepted
+    ~ shareRegistrations - set IP or DNS name indicating the servers that
+                           should receive shared registration requests
+    ~ siblingCertDir - location where the sibling certs may be stored
+  + Example implementation of verification code
+  + Support deletion of registrations on the sibling server(s) in
+    smt-delete-registration
+  + HA functionality is encapsulated in -ha sub-package
+  + Implement plugin mechanism to allow cloud specific functionality
+    to be maintained separately
+
+-------------------------------------------------------------------
 Tue Apr 26 16:27:45 CEST 2016 - mc@suse.de
 
 - Convert Patches table to UTF8 (bsc#977002)

--- a/package/smt.spec
+++ b/package/smt.spec
@@ -63,6 +63,36 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 This package provide everything you need to get a local NU and
 registration proxy.
 
+%package ha
+Summary:     SMT HA setup
+Group:       Productivity/Networking/Web/Proxy
+PreReq:      smt = %version
+Requires:    perl-File-Touch
+Requires:    perl-File-Slurp
+Requires:    perl-XML-LibXML
+
+%description ha
+This package extends the basic SMT functionality with registration sharing
+capabilities. This allows 2 or more SMT servers running at the same time to
+share the registrations they receive. The following smt.conf options are
+used.
+
+#
+# This string is used to verify that any sender trying to share a
+# registration is allowed to do so. Provide a comma separated list of
+# names or IP addresses.
+acceptRegistrationSharing=
+#
+# This string is used to set the host names and or IP addresses of sibling
+# SMT servers to which the registration data should be sent. For multiple
+# siblings provide a comma separated list.
+shareRegistrations=
+#
+# This string provides information for SSL verification of teh siblings.
+# Certificates for the siblings should reside in the given directory.
+# If not defined siblings are assumed to have the same CA as this server
+siblingCertDir=
+
 %package -n res-signingkeys
 Summary:        Signing Key for RES
 Group:          Productivity/Security
@@ -225,6 +255,7 @@ fi
 %exclude %{_sysconfdir}/apache2/conf.d/smt_support.conf
 %config %{_sysconfdir}/cron.d/novell.com-smt
 %config %{_sysconfdir}/logrotate.d/smt
+%exclude %{perl_vendorlib}/SMT/RegistrationSharing.pm
 %{perl_vendorlib}/SMT.pm
 %{perl_vendorlib}/SMT/*.pm
 %{perl_vendorlib}/SMT/Job/*.pm
@@ -236,12 +267,15 @@ fi
 %{perl_vendorarch}/auto/Sys/GRP/*.so
 /srv/www/perl-lib/NU/*.pm
 /srv/www/perl-lib/SMT/*.pm
+%exclude /srv/www/perl-lib/SMT/Client/exampleVerify.pm
 /srv/www/perl-lib/SMT/Client/*.pm
 %exclude /srv/www/perl-lib/SMT/Support.pm
 %{_sbindir}/smt-*
 %exclude %{_sbindir}/smt-support
+%exclude /usr/sbin/smt-sibling-sync
 %{_sbindir}/smt
 %{_libexecdir}/SMT/bin/*
+%exclude %{_libexecdir}/SMT/bin/shareRegistration.pl
 %{_bindir}/smt*
 %{_libexecdir}/systemd/system/smt.target
 %{_libexecdir}/systemd/system/smt.service
@@ -253,6 +287,13 @@ fi
 %doc %attr(644, root, root) %{_mandir}/man1/*
 %exclude %{_mandir}/man1/smt-support.1.gz
 %doc %{_docdir}/smt/*
+
+%files ha
+%defattr(-,root,root)
+/srv/www/perl-lib/SMT/Client/exampleVerify.pm
+/usr/lib/SMT/bin/shareRegistration.pl
+%{perl_vendorlib}/SMT/RegistrationSharing.pm
+%{_sbindir}/smt-sibling-sync
 
 %files -n res-signingkeys
 %defattr(-,root,root)

--- a/script/smt-sibling-sync
+++ b/script/smt-sibling-sync
@@ -1,0 +1,91 @@
+#!/usr/bin/perl
+
+###############################################################################
+## Copyright (c) 2016 SUSE LLC
+###############################################################################
+
+use strict;
+use warnings;
+use Getopt::Long;
+use SMT::Utils;
+use SMT::RegistrationSharing;
+
+if(!SMT::Utils::dropPrivileges())
+{
+    print STDERR __("Unable to drop privileges. Abort!\n");
+    exit 1;
+}
+
+my $help  = 0;
+my $logfile = "/dev/null";
+
+my $optres = GetOptions ("logfile|L=s" => \$logfile,
+                         "help|h"      => \$help
+                        );
+
+if($help) {
+    print basename($0) . __(" [OPTIONS]\n");
+    print __("Sync this SMT server with its configured siblings\n");
+    print "\n";
+    print __("Options:\n");
+    print "  --logfile (-L) <file>  : " . __("Path to logfile")."\n";
+    exit 0;
+}
+
+my $log = SMT::Utils::openLog($logfile);
+
+my $dbh = SMT::Utils::db_connect();
+my $statement = 'SELECT GUID from Registration';
+my $guids = $dbh->selectcol_arrayref($statement);
+
+if (! $guids) {
+    print "This server has no registrations, nothing to do\n";
+    exit 0;
+}
+
+for my $guid (@{$guids}) {
+    SMT::RegistrationSharing::shareRegistration($guid, $log);
+}
+
+#
+# Manpage
+#
+
+=head1 NAME
+
+smt-sibling-sync
+
+=head1 SYNOPSIS
+
+smt-sibling-sync
+
+=head1 DESCRIPTION
+
+I<smt-sibling-sync> syncs all registered clients with the configured sibling SMT server(s). The sibling SMT server(s) are configured with the shareRegistrations configuration option.
+
+=head1 OPTIONS
+
+None
+
+=head1 AUTHORS and CONTRIBUTORS
+
+Robert Schweikert
+
+=head1 LICENSE
+
+Copyright (c) 2016 SUSE LLC
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 675 Mass
+Ave, Cambridge, MA 02139, USA.
+
+=cut

--- a/tests/SMT/shareRegistration.pl
+++ b/tests/SMT/shareRegistration.pl
@@ -1,0 +1,84 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+
+use Data::Dumper;
+use Config::IniFiles;
+use Getopt::Long;
+use SMT::Utils;
+use WWW::Curl::Easy;
+
+my $smtHost;
+my $config;
+GetOptions ('config=s' => \$config,
+            'host=s' => \$smtHost);
+
+if (! $smtHost && ! $config) {
+    my $msg = 'Must specify the target SMT server with --host or config '
+        . "file with --config.\n";
+    print $msg;
+    exit 1;
+}
+
+if ($config && ! -f $config) {
+    print "could not find configuration file '$config'\n";
+    exit 1;
+}
+
+my $regInfo = "<?xml version='1.0' encoding='UTF-8'?>"
+    . "<registrationData>"
+    . "<tableData table='Clients'>"
+    . "<entry comulmnName='NAMESPACE' value=''/>"
+    . "<entry comulmnName='HOSTNAME' value='smt-client'/>"
+    . "<entry comulmnName='TARGET' value='sle-11-x86_64'/>"
+    . "<entry comulmnName='GUID' value='03a8f41f176d4776aed0ea2263ea82c4'/>"
+    . "<entry comulmnName='SECRET' value='efaf1ed2f80a4548b4904dc5888f9958'/>"
+    . "<entry comulmnName='DESCRIPTION' value=''/>"
+    . "<entry comulmnName='REGTYPE' value='SR'/>"
+    . "<entry comulmnName='LASTCONTACT' value='2014-08-27 13:41:11'/>"
+    . "</tableData>"
+    . "<tableData table='Registration'>"
+    . "<entry comulmnName='REGDATE' value='2014-08-26 09:58:15'/>"
+    . "<entry comulmnName='NCCREGERROR' value='0'/>"
+    . "<entry comulmnName='NCCREGDATE' value=''/>"
+    . "<entry comulmnName='GUID' value='03a8f41f176d4776aed0ea2263ea82c4'/>"
+    . "<entry comulmnName='PRODUCTID' value='100550'/>"
+    . "</tableData>"
+    . "</registrationData>";
+
+my $shareRegDataTargets;
+my $certPath;
+
+if ($config) {
+    my $cfg = new Config::IniFiles( -file => $config );
+    $shareRegDataTargets = $cfg->val('LOCAL', 'shareRegistrations');
+    if (! $shareRegDataTargets) {
+        print "No registration sharing configured in '$config'\n";
+        exit 1;
+    }
+    $certPath = $cfg->val('LOCAL', 'siblingCertDir');
+}
+else {
+    $shareRegDataTargets = $smtHost;
+}
+
+my @smtSiblings = split /,/, $shareRegDataTargets;
+for my $smtServer (@smtSiblings) {
+    my $ua = SMT::Utils::createUserAgent();
+    if ($certPath) {
+        $ua->setopt(CURLOPT_CAPATH, $certPath);
+    }
+    my $url = "https://$smtServer/center/regsvc"
+                . '?command=shareregistration'
+                . '&lang=en-US&version=1.0';
+    my $response = $ua->post($url, Content=>$regInfo);
+
+    if (! $response->is_success) {
+        my $dd = Data::Dumper->new([ $response ]);
+        print $dd->Dump();
+        print "Test FAILED for host '$smtServer'\n";
+    }
+    else {
+        print "SUCCESS for host '$smtServer'\n";
+    }
+}

--- a/www/perl-lib/SMT/Client/exampleVerify.pm
+++ b/www/perl-lib/SMT/Client/exampleVerify.pm
@@ -13,7 +13,26 @@ sub verifyGuest {
     my $regroot = shift;
     # Insert code to connect to cloud framework and verify the guest
     # return 1 for successful verification, undef for verification failure
+    # $r -> the request, i.e an Apache request object
+    #       http://perl.apache.org/docs/2.0/api/Apache2/RequestRec.html
+    # $regroot ->  HASHREF containing information sent by the client.
     return 1;
+}
+
+sub verifySCCGuest {
+
+    my $self     = shift;
+    my $r        = shift;
+    my $clntData = shift;
+    my $result   = shift;
+    # Insert code to connect to cloud framework and verify the guest
+    # return the result HASHREF for successful verification, undef for
+    # verification failure
+    # $r -> the request, i.e an Apache request object
+    #       http://perl.apache.org/docs/2.0/api/Apache2/RequestRec.html
+    # $clntData -> data received from the client
+    # $result -> HASHREF of results of various previous operations
+    return $result;
 }
 
 1;

--- a/www/perl-lib/SMT/RegistrationSharing.pm
+++ b/www/perl-lib/SMT/RegistrationSharing.pm
@@ -1,0 +1,567 @@
+package SMT::RegistrationSharing;
+
+use strict;
+use warnings;
+
+use Apache2::Log;
+use Apache2::RequestRec ();
+use Apache2::ServerUtil ();
+use DBI qw(:sql_types);
+use File::Slurp;
+use File::Temp;
+use File::Touch;
+use SMT::Utils;
+use WWW::Curl::Easy;
+use XML::LibXML;
+#
+# called from handler in Registration module if registration is shared
+# from another SMT server
+# command=shareregistration argument given
+sub addSharedRegistration
+{
+    my $r     = shift;
+    my $hargs = shift;
+
+    my $apache = Apache2::ServerUtil->server;
+    my $acceptRequest = _verifySenderAllowed($r);
+    if ($acceptRequest != 1) {
+        return $acceptRequest;
+    }
+    # Process the registration request
+    my $regData = SMT::Utils::read_post($r);
+    my $regXML = _getXMLFromPostData($regData);
+    if (! $regXML)
+    {
+        my $msg = "Received invalid data:\n$@\n";
+        $apache->log_error($msg);
+        $r->log_error($msg);
+        return SMT::Utils::http_fail($r, 400, $msg);
+
+    }
+    my $dbh = SMT::Utils::db_connect();
+    my @tableEntries = $regXML->getElementsByTagName('tableData');
+    my $guid = _getGUIDfromTableEntry($tableEntries[0]);
+    if (SMT::Utils::lookupClientByGUID($dbh, $guid)) {
+        $dbh->disconnect();
+        $apache->log->info("Already have entry for '$guid' nothing to do");
+        return;
+    }
+    for my $entry (@tableEntries) {
+        $guid = _getGUIDfromTableEntry($entry);
+        my $statement = _createInsertSQLfromXML($r, $dbh, $entry);
+        if (! $statement) {
+            $dbh->disconnect();
+            my $msg = 'Could not generate SQL statement to insert '
+                . 'registration';
+            $r->log_error($msg);
+            return SMT::Utils::http_fail($r, 400, $msg);
+        }
+        eval {
+            $dbh->do($statement)
+        };
+        if ($@) {
+            $dbh->disconnect();
+            $r->log_error('Unable to insert registration into SMT database');
+            my $msg = 'Registration insert failed:\n'
+                . "STATEMENT: $statement\n"
+                . "Error: $@";
+            $apache->log_error($msg);
+            return SMT::Utils::http_fail($r, 400, $msg);
+        }
+    }
+    $dbh->disconnect();
+    return;
+}
+
+#
+# called from handler in Registration module if registration is shared
+# from another SMT server
+# command=deltesharedregistration argument given
+sub deleteSharedRegistration
+{
+    my $r     = shift;
+    my $hargs = shift;
+
+    my $apache = Apache2::ServerUtil->server;
+    my $acceptRequest = _verifySenderAllowed($r);
+    if ($acceptRequest != 1) {
+        return $acceptRequest;
+    }
+    # Process the delete request
+    my $guidData = SMT::Utils::read_post($r);
+    my $delXML = _getXMLFromPostData($guidData);
+    if (! $delXML)
+    {
+        my $msg = "Received invalid data:\n$@\n";
+        $apache->log_error($msg);
+        $r->log_error($msg);
+        return SMT::Utils::http_fail($r, 400, $msg);
+    }
+    my @guids = $delXML->getElementsByTagName('guid');
+    # There is only one guid element in the XML
+    my $guid = $guids[0]->textContent();
+    if (! $guid)
+    {
+        my $msg = 'No GUID received for deletion';
+        $r->log_error($msg);
+        return SMT::Utils::http_fail($r, 400, $msg);
+    }
+    my $dbh = SMT::Utils::db_connect();
+    my $found = 0;
+    my $where = sprintf("GUID = %s", $dbh->quote( $guid ) );
+    my $statement = "DELETE FROM Registration where ".$where;
+    my $res = $dbh->do($statement);
+    if ( $res > 0)
+    {
+        $found = 1;
+    }
+    $statement = "DELETE FROM Clients where ".$where;
+    $res = $dbh->do($statement);
+    $statement = "DELETE FROM MachineData where ".$where;
+    $res = $dbh->do($statement);
+    $dbh->disconnect();
+
+    if(! $found)
+    {
+        $apache->log->info("No registration with $guid found.");
+    }
+
+    return;
+}
+
+#
+# called from NCCRegTools::NCCDeleteRegistration if registration is shared
+# with another SMT server
+#
+sub deleteSiblingRegistration
+{
+    my $regGUID = shift;
+    my $logfile = shift;
+    my $log = SMT::Utils::openLog($logfile);
+    my $cfg;
+    eval
+    {
+        $cfg = SMT::Utils::getSMTConfig();
+    };
+    if($@ || !defined $cfg)
+    {
+        my $msg = 'Cannot read the SMT configuration file: '.$@;
+        print $log $msg;
+        return;
+    }
+    my $shareRegDataTargets = $cfg->val('LOCAL', 'shareRegistrations');
+    if (! $shareRegDataTargets) {
+        return 1;
+    }
+    my $guidXML = '<?xml version="1.0" encoding="UTF-8"?>'
+        . '<deleteRegistrationData>'
+        . '<guid>'
+        . $regGUID
+        . '</guid>'
+        . '</deleteRegistrationData>';
+    # SSL handling
+    my $certPath = $cfg->val('LOCAL', 'siblingCertDir');
+    # Send the registration data to the configured SMT siblings
+    my @smtSiblings = split /,/, $shareRegDataTargets;
+    for my $smtServer (@smtSiblings) {
+        my $ua = SMT::Utils::createUserAgent();
+        if ($certPath) {
+            $ua->setopt(CURLOPT_CAPATH, $certPath);
+        }
+        my $url = "https://$smtServer/center/regsvc"
+            . '?command=deltesharedregistration'
+            . '&lang=en-US&version=1.0';
+        my $response = $ua->post($url, Content=>$guidXML);
+        if (! $response->is_success ) {
+            my $msg = $response->message;
+            my $details = $response->content;
+            my $guidMsg = "Could not delete shared registration for $regGUID";
+            my $responseMsg = "Response: $msg";
+            my $detailsMsg = "Response: $details";
+            print $log $guidMsg . "\n";
+            print $log $responseMsg . "\n";
+            print $log $detailsMsg . "\n";
+        }
+    }
+    return;
+}
+
+#
+# called from register in Registration module if registration is shared
+# with another SMT server. The log argument is an indicator if the
+# registration sharing is triggered from a command line tool.
+#
+sub shareRegistration
+{
+    my $regGUID = shift;
+    my $log     = shift;
+    my $apache;
+    if (! $log) {
+        $apache = Apache2::ServerUtil->server;
+    }
+    # Get the configuration
+    my $cfg;
+    eval
+    {
+        $cfg = SMT::Utils::getSMTConfig();
+    };
+    if($@ || !defined $cfg)
+    {
+        my $msg = 'Cannot read the SMT configuration file: '.$@;
+        if ($log) {
+            print $log $msg;
+        } else {
+            $apache->log_error($msg);
+        }
+        return;
+    }
+    my $shareRegDataTargets = $cfg->val('LOCAL', 'shareRegistrations');
+    if (! $shareRegDataTargets) {
+        return 1;
+    }
+    my $dbh = SMT::Utils::db_connect();
+    # Setup the registration data as an XML string
+    my @tableData = ('Clients', 'Registration');
+    my $regXML = '<?xml version="1.0" encoding="UTF-8"?>'
+        . '<registrationData>';
+    # Get the registration data
+    for my $table (@tableData) {
+        my $statement = sprintf("SELECT * from %s where GUID=%s",
+                                $table,
+                                $dbh->quote($regGUID));
+        my $regData = $dbh->selectrow_hashref($statement);
+        if (! $regData) {
+            next;
+        }
+        my $skip;
+        if ($table eq 'Clients') {
+            my @skipColumn = ('ID');
+            $skip = \@skipColumn;
+        }
+        $regXML .= "<tableData table='$table'>"
+            . _getXMLFromRowData($regData, $skip)
+            . '</tableData>';
+    }
+    $regXML .= '</registrationData>';
+
+    # Send the registration data to the configured SMT siblings
+    if ( $regXML =~ /GUID/) {
+        my @smtSiblings = split /,/, $shareRegDataTargets;
+        for my $smtServer (@smtSiblings) {
+            my $url = "https://$smtServer/center/regsvc"
+                . '?command=shareregistration'
+                . '&lang=en-US&version=1.0';
+            my $response = _sendData($url, $regXML, $log);
+            if (! $response ) {
+                return;
+            }
+            if (! $response->is_success ) {
+                my $msg = $response->message;
+                my $details = $response->content;
+                my $guidMsg = "Could not share registration for $regGUID";
+                my $responseMsg = "Response: $msg";
+                my $detailsMsg = "Response: $details";
+                if ($log) {
+                    print $log $guidMsg . "\n";
+                    print $log $responseMsg . "\n";
+                    print $log $detailsMsg . "\n";
+                } else {
+                    $apache->warn($guidMsg);
+                    $apache->warn($responseMsg);
+                    $apache->warn($detailsMsg);
+                    _logShareRecord($smtServer,$url,$regXML);
+                }
+
+            } else {
+                _sharePreviousRegistrations($smtServer, $log);
+            }
+        }
+    }
+    $dbh->disconnect();
+    return;
+}
+
+#
+# Private
+#
+#
+# Generate the SQL statement to insert the registration that is being shared
+# into the DB
+#
+sub _createInsertSQLfromXML
+{
+    my $r       = shift;
+    my $dbh     = shift;
+    my $element = shift;
+    my $tableName = $element->getAttribute('table');
+    if (! $tableName) {
+        $dbh->disconnect();
+        my $xml = $element->textContent;
+        my $msg = "Could not determine table name for insertion from XML\n"
+            . $xml;
+        $r->log_error($msg);
+        return SMT::Utils::http_fail($r, 400, $msg);
+    }
+    my $sql = "INSERT into $tableName (";
+    my $vals = 'VALUES (';
+    for my $entry ($element->getElementsByTagName('entry')) {
+        $sql .= $entry->getAttribute('comulmnName')
+            . ', ';
+        my $val = $dbh->quote($entry->getAttribute('value'));
+        $vals .= "$val"
+            . ', ';
+    }
+    chop $sql; # remove trailing space
+    chop $sql; # remove trailing comma
+    chop $vals; # remove trailing space
+    chop $vals; # remove trailing comma
+
+    $sql .= ') ' . $vals . ')';
+
+    return $sql;
+}
+
+#
+# Get the Global ID for the given DB entry
+#
+sub _getGUIDfromTableEntry
+{
+    my $tableXML = shift;
+    for my $entry ($tableXML->getElementsByTagName('entry')) {
+        if ($entry->getAttribute('comulmnName') eq 'GUID') {
+            return $entry->getAttribute('value');
+        }
+    }
+    return;
+}
+
+#
+# Process the received data and turn it into an XML object
+#
+sub _getXMLFromPostData
+{
+    my $postData = shift;
+    my $xml;
+    my $parser = XML::LibXML->new();
+    eval {
+        # load_xml not available on SLES 11 SP3 due to version of
+        # LibXML and underlying libxml2
+        #$xm = XML::LibXML->load_xml(string => $postData);
+        my $POSTDATAFL = File::Temp->new(SUFFIX=>'.txt');
+        $POSTDATAFL->write($postData);
+        $POSTDATAFL->flush();
+        seek $POSTDATAFL, 0,0;
+        $xml = $parser->parse_fh($POSTDATAFL);
+    };
+
+    if ($@) {
+        return;
+    }
+    return $xml;
+}
+
+#
+# Turn DB data into XML format
+#
+sub _getXMLFromRowData
+{
+    my $rowData     = shift;
+    my $skipEntries = shift;
+    my %skip = map { ($_ => 1) } @{$skipEntries};
+    my %data = %{$rowData};
+    my @entries = keys %data;
+    my $xml = '';
+    for my $entry (@entries) {
+        if ($skip{$entry}) {
+            next;
+        }
+        if ($data{$entry}) {
+            $xml .= "<entry comulmnName='$entry' value='"
+                . $data{$entry}
+                . "'/>";
+        }
+    }
+    return $xml;
+}
+
+#
+# log a record to be shared such that it can be replayed once the
+# sibling server is back online
+#
+sub _logShareRecord{
+    my $logFileName = shift;
+    my $url         = shift;
+    my $regXML      = shift;
+    my $apache = Apache2::ServerUtil->server;
+
+    if (! -d '/var/lib/wwwrun/smt') {
+        my $status = mkdir '/var/lib/wwwrun/smt';
+        if (! $status) {
+            my $msg = 'Could not create "/var/lib/wwwrun/smt" to log failed '
+                . 'shared registration record.';
+            $apache->warn($msg);
+            return;
+        }
+    }
+    my $log = "/var/lib/wwwrun/smt/$logFileName";
+    my $lockFile = $log . '.lock';
+    while (-e $lockFile) {
+        sleep 1;
+    }
+    touch($lockFile);
+    my $status = open my $LOGFILE, '>>', $log;
+    if (! $status) {
+        my $msg = "Could not open log '$logFileName' for writing";
+        $apache->warn($msg);
+        my $errMsg = 'Could not create record in replay file. '
+            . 'The following must be added manually to the '
+            . 'configured sibling servers:'
+            . "\n$regXML";
+        $apache->error($errMsg);
+        unlink $lockFile;
+        return;
+    }
+    print $LOGFILE "$url";
+    print $LOGFILE '+++'; # Arbitrary separator used on playback
+    print $LOGFILE "$regXML\n";
+    close $LOGFILE;
+    unlink $lockFile;
+    return 1;
+}
+
+#
+# Send given data to the given url. The log argument is an indicator if the
+# registration sharing is triggered from a command line tool.
+#
+sub _sendData{
+    my $url  = shift;
+    my $data = shift;
+    my $log  = shift;
+
+    my $apache;
+    if (! $log) {
+        $apache = Apache2::ServerUtil->server;
+    }
+    # Get the configuration
+    my $cfg;
+    eval
+    {
+        $cfg = SMT::Utils::getSMTConfig();
+    };
+    if($@ || !defined $cfg)
+    {
+        my $msg = 'Cannot read the SMT configuration file: '.$@
+            . "\nUnable to read cert data for ssl handling.";
+        if ($log) {
+            print $log $msg;
+        } else {
+            $apache->log_error($msg);
+        }
+        return;
+    }
+
+    my $certPath = $cfg->val('LOCAL', 'siblingCertDir');
+    my $ua = SMT::Utils::createUserAgent();
+    if ($certPath) {
+        $ua->setopt(CURLOPT_CAPATH, $certPath);
+    }
+    return $ua->post($url, Content=>$data);
+}
+
+#
+# Share registrations that may have been logged due to a sibling server
+# beeing unreachable at one time.  The log argument is an indicator if the
+# registration sharing is triggered from a command line tool.
+#
+sub _sharePreviousRegistrations{
+    my $logFileName = shift;
+    my $log         = shift;
+
+    if (! -d '/var/lib/wwwrun/smt') {
+        return;
+    }
+
+    my $replayLog = "/var/lib/wwwrun/smt/$logFileName";
+    if (! -e $replayLog) {
+        return;
+    }
+
+    if ($log) {
+        unlink $replayLog;
+        return;
+    }
+
+    my $lockFile = $replayLog . '.lock';
+    while (-e $lockFile) {
+        sleep 1;
+    }
+    touch($lockFile);
+
+    my @undeliverdRecords;
+    my @records = File::Slurp::read_file($replayLog);
+    for my $record (@records) {
+        (my $url, my $regXML) = split /\+\+\+/, $record;
+        my $response = _sendData($url, $regXML, $log);
+        if (! $response) {
+            return;
+        }
+        if (! $response->is_success ) {
+            push @undeliverdRecords, $record;
+        }
+    }
+    unlink $lockFile;
+    unlink $replayLog;
+    if (@undeliverdRecords) {
+        for my $record (@undeliverdRecords) {
+            (my $url, my $regXML) = split /\+\+\+/, $record;
+            _logShareRecord($logFileName,$url,$regXML);
+        }
+    }
+}
+
+#
+# Verify that it is OK to accept the request
+#
+sub _verifySenderAllowed
+{
+    my $r = shift;
+
+    my $apache = Apache2::ServerUtil->server;
+    my $senderName = $r->hostname();
+    my $senderIP = $r->connection()->client_ip();
+    my $msg = 'Received shared registration request from '
+        . $senderName
+        . ':'
+        . $senderIP;
+    $apache->log->info($msg);
+
+    # Verify that it is OK to accept the registration from this host
+    my $cfg;
+    eval
+    {
+        $cfg = SMT::Utils::getSMTConfig();
+    };
+    if($@ || !defined $cfg)
+    {
+        $r->log_error("Cannot read the SMT configuration file: ".$@);
+        return SMT::Utils::http_fail($r, 500,
+           "SMT server is missconfigured. Please contact your administrator.");
+    }
+    my $allowedSenders = $cfg->val('LOCAL', 'acceptRegistrationSharing');
+    my %acceptedProviders;
+    if ($allowedSenders) {
+        %acceptedProviders = map { ($_ => 1) } split /,/, $allowedSenders;
+    }
+
+    if ((! $acceptedProviders{$senderName})
+        && (! $acceptedProviders{$senderIP})) {
+        $msg = "Registration data not accepted, host $senderIP, not listed "
+            . 'as "acceptRegistrationSharing" provider in config file.';
+        $r->log_error($msg);
+        return SMT::Utils::http_fail($r, 403, $msg);
+    }
+
+    return 1;
+}
+
+1;

--- a/www/perl-lib/SMT/Rest/Base.pm
+++ b/www/perl-lib/SMT/Rest/Base.pm
@@ -56,6 +56,24 @@ sub new
                 '_cfg' => $cfg,
                 '_usr' => $r->user
     };
+
+    if (SMT::Utils::hasRegSharing($r) && ! $self->{regsharing} ) {
+        eval
+        {
+            require 'SMT/RegistrationSharing.pm';
+            #require SMT::RegistrationSharing;
+        };
+        if ($@)
+        {
+            my $msg = 'Failed to load registration sharing module '
+                . '"SMT/RegistrationSharing.pm"'
+                . "\n$@";
+            $r->log_error($msg);
+        }
+        # Plugin successfully loaded
+        $self->{regsharing} = 1;
+    }
+
     bless $self, $class;
     return $self;
 }

--- a/www/perl-lib/SMT/Rest/SCCAPIv1.pm
+++ b/www/perl-lib/SMT/Rest/SCCAPIv1.pm
@@ -354,7 +354,6 @@ sub products
         }
     }
 
-
     #
     # lookup the Clients target
     #
@@ -601,6 +600,13 @@ sub announce
     {
         $self->request()->log_error(sprintf("SMT Registration error: Could not create initial patchstatus reporting job for client with guid: %s  ",
                                             $result->{login} )  );
+    }
+
+    #
+    # share the registration
+    #
+    if ($self->{regsharing}) {
+        SMT::RegistrationSharing::shareRegistration($result->{login});
     }
 
     return (Apache2::Const::OK, $result);

--- a/www/perl-lib/SMT/Utils.pm
+++ b/www/perl-lib/SMT/Utils.pm
@@ -37,6 +37,8 @@ use English;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(__ __N printLog LOG_ERROR LOG_WARN LOG_INFO1 LOG_INFO2 LOG_DEBUG LOG_DEBUG2 LOG_DEBUG3);
 
+my $REGSHARING = undef;
+
 use constant IOBUFSIZE => 8192;
 use constant LOG_ERROR  => 0x0001;
 use constant LOG_WARN   => 0x0002;
@@ -126,6 +128,46 @@ sub db_connect
 
     return $dbh;
 }
+
+=item hasRegSharing()
+
+Check whether registration sharing is enabled or not.
+
+=cut
+
+sub hasRegSharing
+{
+    my $r = shift;
+
+    if (! defined $REGSHARING) {
+        $REGSHARING = 0;
+        my $cfg;
+        eval
+        {
+            $cfg = SMT::Utils::getSMTConfig();
+        };
+        if($@ || !defined $cfg)
+        {
+            if ($r)
+            {
+                $r->log_error("Cannot read the SMT configuration file: ".$@);
+                my $msg = 'SMT server is missconfigured. Please contact your '
+                  . 'administrator.';
+                http_fail($r, 500, $msg);
+            }
+            return;
+        }
+        my $allowedSenders = $cfg->val('LOCAL', 'acceptRegistrationSharing');
+        my $shareRegDataTargets = $cfg->val('LOCAL', 'shareRegistrations');
+
+        if ($allowedSenders && $shareRegDataTargets) {
+            $REGSHARING = 1;
+        }
+    }
+
+    return $REGSHARING;
+}
+
 
 =item __()
 


### PR DESCRIPTION
  + Registration sharing allows two completely independently configured
    SMT servers to be configured as sibling servers. The sibling servers
    share registration information effectively creating an redundant
    setup. Code that can be implemented in the client can detect if the
    SMT server that it registered to is available, if not it can fail
    over to the sibling server and get access to the repositories with
    the same registration credentials.