### PR TITLE
Add a way to download just the metadata and product rpms when mirroring

### DIFF
--- a/www/perl-lib/SMT/Mirror/RpmMd.pm
+++ b/www/perl-lib/SMT/Mirror/RpmMd.pm
@@ -96,6 +96,9 @@ repository.
 
 =cut
 
+# For integration tests, intentionally not exposed to configs or command line
+our $download_only_metadata = 0;
+
 sub new
 {
     my $pkgname = shift;
@@ -921,6 +924,10 @@ sub mirror()
             $self->{STATISTIC}->{DOWNLOAD} += 1;
 
             next;
+        }
+
+        if ( $download_only_metadata ) {
+            next if ( $r !~ /\-release/ and $r !~ /lifecycle-data/ );
         }
 
         my $mres = $self->{JOBS}->{$r}->mirror();


### PR DESCRIPTION
I'm setting up integration tests for SMT and SUSEConnect, the latter needs metadata and product-related rpms in order to enable extensions. Mirroring all the packages in the mirrored repos just takes too long.