### PR TITLE
Use official RSC based images for integration testing

### DIFF
--- a/tests/integration/smt_client/Dockerfile
+++ b/tests/integration/smt_client/Dockerfile
@@ -1,7 +1,13 @@
-FROM registry.scc.suse.de/connect_sp2
+FROM registry.suse.com/sles12sp2
 
-RUN zypper ref && zypper --non-interactive install --no-recommend \
-    timezone
+RUN zypper --non-interactive rm container-suseconnect &&\
+    zypper --non-interactive ar \
+      http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP2/x86_64/product/ sles12sp2_pool &&\
+    zypper --non-interactive ar \
+      http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP2/x86_64/update sles12sp2_updates &&\
+    zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-SDK/12-SP2/x86_64/product sles12sp2_sdk &&\ 
+    zypper ref && zypper --non-interactive install --no-recommend \
+    timezone patch mariadb-client libopenssl-devel
 
 ADD files/run.sh /root/run.sh
 

--- a/tests/integration/smt_server/Dockerfile
+++ b/tests/integration/smt_server/Dockerfile
@@ -1,6 +1,12 @@
-FROM registry.scc.suse.de/connect_sp2
+FROM registry.suse.com/sles12sp2
 
-RUN zypper ref && zypper --non-interactive install --no-recommend \
+RUN zypper --non-interactive rm container-suseconnect &&\
+    zypper --non-interactive ar \
+      http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP2/x86_64/product/ sles12sp2_pool &&\
+    zypper --non-interactive ar \
+      http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP2/x86_64/update sles12sp2_updates &&\
+    zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-SDK/12-SP2/x86_64/product sles12sp2_sdk &&\ 
+    zypper ref && zypper --non-interactive install --no-recommend \
     timezone patch mariadb-client libopenssl-devel
 
 ADD files/smt_current.rpm /root/smt_current.rpm


### PR DESCRIPTION
The reasoning:

1) they are official
2) supposed to be updated regularly
3) they have fixed version of libzypp which addresses link issue on overlayfs2