### PR TITLE
Fix cronjob

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME          = smt
-VERSION       = 3.0.35
+VERSION       = 3.0.36
 DESTDIR       = /
 PERL         ?= perl
 PERLMODDIR    = $(shell $(PERL) -MConfig -e 'print $$Config{installvendorlib};')

--- a/cron/novell.com-smt
+++ b/cron/novell.com-smt
@@ -1,11 +1,6 @@
-# SMT cron.d configuration
-#     default:
-#     run smt-register every 15 minutes
-#     run smt-daily once a night at 01:00 +
-#     run smt-run-jobqueue-cleanup once a night at 02:00 +
-#     run smt-gen-report once a week Monday at 05:00
+# This file needs to be processed by reschedule-sync.sh first in order to randomize the job times
 
-*/15  *  *  *  *    root    /usr/lib/SMT/bin/smt-repeated-register
-0     1  *  *  *    root    /usr/lib/SMT/bin/smt-daily
-0     2  *  *  *    root    /usr/lib/SMT/bin/smt-run-jobqueue-cleanup
-0     5  *  *  1    root    /usr/lib/SMT/bin/smt-gen-report
+### */15  *  *  *  *    root    /usr/lib/SMT/bin/smt-repeated-register
+### 0     1  *  *  *    root    /usr/lib/SMT/bin/smt-daily
+### 0     2  *  *  *    root    /usr/lib/SMT/bin/smt-run-jobqueue-cleanup
+### 0     5  *  *  1    root    /usr/lib/SMT/bin/smt-gen-report

--- a/package/smt.changes
+++ b/package/smt.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul  5 15:12:33 UTC 2018 - ikapelyukhin@suse.com
+
+- version 3.0.36
+- Fix cron jobs randomization (bsc#1097560)
+
+-------------------------------------------------------------------
 Wed Jun 27 13:52:16 UTC 2018 - ikapelyukhin@suse.com
 
 - version 3.0.35

--- a/package/smt.spec
+++ b/package/smt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           smt
-Version:        3.0.35
+Version:        3.0.36
 Release:        0
 Summary:        Subscription Management Tool
 License:        GPL-2.0+
@@ -209,6 +209,8 @@ EOT
     fi
 fi
 
+/usr/lib/SMT/bin/reschedule-sync.sh
+
 %preun
 %service_del_preun smt-schema-upgrade.service
 %service_del_preun smt.service
@@ -216,6 +218,11 @@ fi
 
 # no postun service handling for target or schema-upgrade, we don't want them to be restarted on upgrade
 %postun
+
+if [ -e /etc/cron.d/novell.com-smt-randomized ]; then
+    rm /etc/cron.d/novell.com-smt-randomized
+fi
+
 %service_del_postun smt.service
 
 %files

--- a/package/smt.spec
+++ b/package/smt.spec
@@ -219,10 +219,6 @@ fi
 # no postun service handling for target or schema-upgrade, we don't want them to be restarted on upgrade
 %postun
 
-if [ -e /etc/cron.d/novell.com-smt-randomized ]; then
-    rm /etc/cron.d/novell.com-smt-randomized
-fi
-
 %service_del_postun smt.service
 
 %files
@@ -298,6 +294,7 @@ fi
 %exclude %{_mandir}/man1/smt-support.1.gz
 %exclude %{_mandir}/man1/smt-sibling-sync.1.gz
 %doc %{_docdir}/smt/*
+%ghost /etc/cron.d/novell.com-smt-randomized
 
 %files ha
 %defattr(-,root,root)

--- a/script/reschedule-sync.sh
+++ b/script/reschedule-sync.sh
@@ -5,44 +5,45 @@
 
 JOBNAME="smt-daily"
 REPORT="smt-gen-report"
-CRONPATH="/etc/cron.d/novell.com-smt"
+CRON_SRC_PATH="/etc/cron.d/novell.com-smt"
+CRON_DST_PATH="/etc/cron.d/novell.com-smt-randomized"
+CRON_RPMSAVE_PATH="/etc/cron.d/novell.com-smt.rpmsave" # needs to be cleaned up if exists from older versions
 
-if [ ! -r "$CRONPATH" ]; then
+if [ -e "$CRON_RPMSAVE_PATH" ]; then
+    rm $CRON_RPMSAVE_PATH
+fi
+
+if [ ! -r "$CRON_SRC_PATH" ]; then
     exit 1
 fi
 
-LINES=`grep $JOBNAME $CRONPATH | wc -l`
-CURRENT_HOUR=`grep $JOBNAME $CRONPATH | awk '{print $2}'`
-
-if [ "$LINES" != "1" -o "$CURRENT_HOUR" != "0" -a "$CURRENT_HOUR" != "1" -a "$CURRENT_HOUR" != "*" ]; then
+if [ -e "$CRON_DST_PATH" ]; then
     # no need to reschedule
     echo "no reschedule needed"
     exit 0
 fi
 
+TMP_FILE=`mktemp "${CRON_DST_PATH}.XXXXXX" 2>/dev/null`
+if [ ! -e $TMP_FILE ]; then
+    echo "unable to create tmp file" >&2
+    exit 1
+fi
+
 # reschedule - calc new time
 
 # HOUR between 20 - 2 (59)
-NEW_HOUR=`echo "($RANDOM % 7 + 20) % 24" | bc`
-
-# MINUTE between 0 - 59
-NEW_MINUTE=`echo "$RANDOM % 60" | bc`
+DAILY_HOUR=`echo "($RANDOM % 7 + 20) % 24" | bc`
+DAILY_MINUTE=`echo "$RANDOM % 60" | bc`
 
 # Report between 4 - 7 am
 REPORT_HOUR=`echo "$RANDOM % 3 + 4" | bc`
 REPORT_MINUTE=`echo "$RANDOM % 60" | bc`
 
-TMP_FILE=`mktemp "${CRONPATH}.XXXXXX" 2>/dev/null`
-if [ ! -e $TMP_FILE ]; then
-    echo "unable to create tmp file" >&2
-    exit 1
-fi
-grep -v -E "$JOBNAME|$REPORT" $CRONPATH > $TMP_FILE
-echo "$NEW_MINUTE $NEW_HOUR * * * root /usr/lib/SMT/bin/smt-daily" >> $TMP_FILE
+grep -v -E "$JOBNAME|$REPORT" $CRON_SRC_PATH | sed s/^###\\s*// > $TMP_FILE
+echo "$DAILY_MINUTE $DAILY_HOUR * * * root /usr/lib/SMT/bin/smt-daily" >> $TMP_FILE
 echo "$REPORT_MINUTE $REPORT_HOUR * * 1 root /usr/lib/SMT/bin/smt-gen-report" >> $TMP_FILE
 
 STAMP=`date +%Y%m%d%H%M%S`
-mv "$CRONPATH" "$CRONPATH.$STAMP"
-mv "$TMP_FILE" "$CRONPATH"
+mv "$TMP_FILE" "$CRON_DST_PATH"
 
 rccron reload

--- a/script/reschedule-sync.sh
+++ b/script/reschedule-sync.sh
@@ -23,10 +23,7 @@ fi
 # reschedule - calc new time
 
 # HOUR between 20 - 2 (59)
-NEW_HOUR=`echo "$RANDOM % 7 - 4" | bc`
-if [ $NEW_HOUR -lt 0 ]; then
-    NEW_HOUR=`echo "24 + $NEW_HOUR" | bc`
-fi
+NEW_HOUR=`echo "($RANDOM % 7 + 20) % 24" | bc`
 
 # MINUTE between 0 - 59
 NEW_MINUTE=`echo "$RANDOM % 60" | bc`

--- a/yast/doc/Makefile.am
+++ b/yast/doc/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for smt/doc
 
-SUBDIRS = autodocs
+SUBDIRS = 
 
 htmldir = $(docdir)
 

--- a/yast/doc/autodocs/.cvsignore
+++ b/yast/doc/autodocs/.cvsignore
@@ -1,3 +1,0 @@
-Makefile
-Makefile.in
-*.html

--- a/yast/doc/autodocs/.gitignore
+++ b/yast/doc/autodocs/.gitignore
@@ -1,5 +1,0 @@
-.yardoc
-*.html
-js
-css
-Yast

--- a/yast/doc/autodocs/Makefile.am
+++ b/yast/doc/autodocs/Makefile.am
@@ -1,3 +1,0 @@
-# Makefile.am for smt/doc/autodocs
-
-include $(top_srcdir)/autodocs-ycp.ami

--- a/yast/package/yast2-smt.changes
+++ b/yast/package/yast2-smt.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 16 12:50:58 UTC 2018 - ikapelyukhin@suse.com
+
+- Remove cron job rescheduling (bsc#1097560)
+- 3.0.14
+
+-------------------------------------------------------------------
 Mon May 22 10:17:25 UTC 2017 - jsrain@suse.cz
 
 - added missing translation marks (bsc#1037811)

--- a/yast/package/yast2-smt.spec
+++ b/yast/package/yast2-smt.spec
@@ -20,7 +20,7 @@
 
 
 Name:           yast2-smt
-Version:        3.0.13
+Version:        3.0.14
 Release:        0
 License:        GPL-2.0
 Group:          System/YaST

--- a/yast/package/yast2-smt.spec
+++ b/yast/package/yast2-smt.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-smt
 #
-# Copyright (c) 2011 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -15,66 +15,67 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-# norootforbuild
-
-
 
 Name:           yast2-smt
 Version:        3.0.14
 Release:        0
-License:        GPL-2.0
-Group:          System/YaST
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        yast2-smt-%{version}.tar.bz2
 
 Prefix:         /usr
 
-Requires:	yast2
+Requires:       yast2
 # FATE 305541: Creating NCCcredentials file using yast2-registration
-Requires:	yast2-registration
-Requires:	/usr/bin/curl
-Requires:	/usr/bin/grep
-Requires:	/bin/hostname
+Requires:       /bin/hostname
+Requires:       /usr/bin/curl
+Requires:       /usr/bin/grep
+Requires:       yast2-registration
 # For adjusting the NCCcredentials file permissions
-Requires:	/usr/bin/setfacl
-Requires:	/bin/chown
-Requires:	/bin/chmod
+Requires:       /bin/chmod
+Requires:       /bin/chown
+Requires:       /usr/bin/setfacl
 # For checking whether the DB->user is available on the system
-Requires:	/usr/bin/getent
+Requires:       /usr/bin/getent
 Requires:       sudo
 # Modified smt-catalogs (added --batch-mode)
 # SMT::Client::getPatchStatusLabel returning two values
 # don't require SMT (instead ask to install it), but prevent older versions
-Conflicts:	smt < 3.0.2
+Conflicts:      smt < 3.0.2
 # Icons
-Requires:	hicolor-icon-theme
+Requires:       hicolor-icon-theme
 # any YaST theme
-Requires:	yast2_theme
+Requires:       yast2_theme
 # 'current'
-PreReq:		yast2-branding
+PreReq:         yast2-branding
 
 # This YaST tool configures SMT (cron, apache2)
-Recommends:	mysql
-Recommends:	cron
-Recommends:	apache2
+Recommends:     mysql
+Recommends:     cron
+Recommends:     apache2
 
 # If CA is missing, SMT offers to create one
-Recommends:	yast2-ca-management
+Recommends:     yast2-ca-management
 
-BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-testsuite
-BuildRequires:	hicolor-icon-theme
+BuildRequires:  hicolor-icon-theme
+BuildRequires:  perl-XML-Writer
+BuildRequires:  update-desktop-files
+BuildRequires:  yast2
+BuildRequires:  yast2-devtools
+BuildRequires:  yast2-testsuite
 # any YaST theme
-BuildRequires:	yast2_theme
+BuildRequires:  yast2_theme
 # build must not have any choice, using package that provides 'yast2-branding'
 %if 0%{?is_opensuse}
-BuildRequires:	yast2-branding-openSUSE
+BuildRequires:  yast2-branding-openSUSE
 %else
-BuildRequires:	yast2-branding-SLES
+BuildRequires:  yast2-branding-SLES
 %endif
 
-BuildArchitectures:	noarch
+BuildArch:      noarch
 
-Summary:	Configuration of Subscription Management Tool for SUSE Linux Enterprise
+Summary:        Configuration of Subscription Management Tool for SUSE Linux Enterprise
+License:        GPL-2.0
+Group:          System/YaST
 
 %description
 Provides the YaST module for SMT configuration.
@@ -160,3 +161,5 @@ rm -rf "$RPM_BUILD_ROOT"
 /usr/share/icons/hicolor/16x16/status/client-*.xpm
 /usr/share/icons/hicolor/16x16/status/repo-*.xpm
 /usr/share/icons/hicolor/16x16/status/patch-*.xpm
+
+%changelog

--- a/yast/src/modules/SMTData.rb
+++ b/yast/src/modules/SMTData.rb
@@ -745,71 +745,12 @@ module Yast
       # to get different 'random' numbers :->>>
       Builtins.srandom
 
-      hour_smt_daily = 20
-      minute_smt_daily = 0
-
-      # randomize smt-daily
-      counter = -1
-      Builtins.foreach(GetCronSettings()) do |one_cron_job|
-        counter = Ops.add(counter, 1)
-        if Builtins.regexpmatch(
-            Ops.get_string(one_cron_job, "command", ""),
-            "smt-daily"
-          )
-          # 20:00 - 02:59
-          hour_calc = Ops.subtract(Builtins.random(7), 4)
-          if Ops.greater_or_equal(hour_calc, 0)
-            hour_smt_daily = hour_calc
-          else
-            hour_smt_daily = Ops.add(24, hour_calc)
-          end
-
-          minute_smt_daily = Builtins.random(59)
-
-          Ops.set(one_cron_job, "hour", Builtins.tostring(hour_smt_daily))
-          Ops.set(one_cron_job, "minute", Builtins.tostring(minute_smt_daily))
-          Builtins.y2milestone(
-            "smt-daily randomized, hour: %1, minute: %2",
-            Ops.get_string(one_cron_job, "hour", ""),
-            Ops.get_string(one_cron_job, "minute", "")
-          )
-          ReplaceCronJob(counter, one_cron_job)
-        end
-      end
-
-      # randomize smt-gen-report
-      counter = -1
-      Builtins.foreach(GetCronSettings()) do |one_cron_job|
-        counter = Ops.add(counter, 1)
-        if Builtins.regexpmatch(
-            Ops.get_string(one_cron_job, "command", ""),
-            "smt-gen-report"
-          )
-          # 4:00 - 6:59
-          hour_report = Ops.add(Builtins.random(3), 4)
-          Ops.set(one_cron_job, "hour", Builtins.tostring(hour_report))
-          Ops.set(one_cron_job, "minute", Builtins.tostring(minute_smt_daily))
-          Builtins.y2milestone(
-            "smt-gen-report randomized, hour: %1, minute: %2",
-            Ops.get_string(one_cron_job, "hour", ""),
-            Ops.get_string(one_cron_job, "minute", "")
-          )
-          ReplaceCronJob(counter, one_cron_job)
-        end
-      end
-
       # randomize smt-repeated-register
       # 450 (seconds) == 7.5 minutes
       SetCredentials(
         "LOCAL",
         "rndRegister",
         Builtins.tostring(Builtins.random(450))
-      )
-
-      # take care the the post script do not reschedule again
-      SCR.Execute(
-        path(".target.bash"),
-        "touch /var/lib/smt/RESCHEDULE_SYNC_DONE"
       )
 
       nil


### PR DESCRIPTION
The plan now would be to:
1. Randomize with `%post` script only, I've removed the relevant Yast parts;
2. Ship the crontab file with everything commented out;
3. Write the randomized version into a file that's not tracked by the RPM to prevent `.rpmsave` issue, remove it in `%postun`.
