### PR TITLE
Fix yast smt module not starting smt

### DIFF
--- a/yast/package/yast2-smt.changes
+++ b/yast/package/yast2-smt.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Dec  5 09:37:19 UTC 2018 - sschricker@suse.com
+
+- the yast smt module correctly starts and stops SMT again, via the
+  corresponding services
+- the associated checkbox was renamed to "Run ..." to better
+  reflect the behaviour
+- 3.0.17
+
+-------------------------------------------------------------------
 Mon Nov 12 12:19:01 UTC 2018 - jsrain@suse.cz
 
 - re-create icon cache after (un-)installation (bsc#1099938)

--- a/yast/package/yast2-smt.spec
+++ b/yast/package/yast2-smt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-smt
-Version:        3.0.16
+Version:        3.0.17
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        yast2-smt-%{version}.tar.bz2

--- a/yast/src/include/smt/dialogs.rb
+++ b/yast/src/include/smt/dialogs.rb
@@ -188,7 +188,7 @@ module Yast
             Left(
               CheckBox(
                 Id("enable_smt_service"),
-                _("&Enable Subscription Management Tool Service (SMT)")
+                _("&Run Subscription Management Tool Service (SMT)")
               )
             ),
             Left("firewall"),

--- a/yast/src/modules/SMTData.rb
+++ b/yast/src/modules/SMTData.rb
@@ -56,7 +56,7 @@ module Yast
 
       @smt_enabled = nil
 
-      @smt_services = ["smt.target"]
+      @smt_services = ["mysql", "smt", "apache2", "smt-schema-upgrade"]
 
       @smt_database = "mysql"
 


### PR DESCRIPTION
* Fix Bug: https://bugzilla.suse.com/show_bug.cgi?id=1106550
* Fix checkbox "Enable Subscription Management Tool Service (SMT)" in
  the Yast SMT Configuration Wizard
* Yast doesn't support and never supported targets in the way we use
  them here (to cheaply bundle services), which leads to breakage when
  the Yast API is changed
* The smt-yast-module itself never supported targets, but only lists of
  services, which meant, that the `WriteSMTServiceStatus` method was
  broken since at least 2008, since the `else` case never did what it
  was supposed to do (Stopping a target doesn't stop the corresponding
  services)
* SMT shouldn't touch `cron.service`, so we dropped it from the list of
  services to start and stop, and assume it is running, which is the
  default on all SLE