### PR TITLE
Truncate patch summaries to db field size (512chr)

### DIFF
--- a/package/smt.changes
+++ b/package/smt.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec  3 13:30:33 UTC 2018 - wstephenson@suse.com
+
+- Version 3.0.39
+- Truncate patch summary to 512 chars (bsc#1117190)
+
+-------------------------------------------------------------------
 Tue Oct  9 14:40:52 UTC 2018 - ikapelyukhin@suse.com
 
 - Version 3.0.38

--- a/www/perl-lib/SMT/Patch.pm
+++ b/www/perl-lib/SMT/Patch.pm
@@ -380,11 +380,16 @@ sub save
         $description = substr($description, 0, SMT::Utils::MYSQL_TEXT_TYPE_SIZE);
     }
 
-    my $sth = $dbh->prepare($sql);
+    my $summary = $self->summary();
+    if (length($summary) > SMT::Utils::PATCH_SUMMARY_SIZE_CHARS) {
+        $summary = substr($summary, 0, SMT::Utils::MYSQL_TEXT_TYPE_SIZE);
+    }
+
+     my $sth = $dbh->prepare($sql);
     $sth->bind_param(1, $self->name(), SQL_VARCHAR);
     $sth->bind_param(2, $self->version(), SQL_VARCHAR);
     $sth->bind_param(3, $self->categoryAsInt(), SQL_INTEGER);
-    $sth->bind_param(4, $self->summary(), SQL_VARCHAR);
+    $sth->bind_param(4, $summary, SQL_VARCHAR);
     $sth->bind_param(5, $description, SQL_VARCHAR);
     $sth->bind_param(6, POSIX::strftime("%Y-%m-%d %H:%M", localtime($self->releaseDate())), SQL_TIMESTAMP);
     $sth->bind_param(7, $self->repoId(), SQL_INTEGER);

--- a/www/perl-lib/SMT/Patch.pm
+++ b/www/perl-lib/SMT/Patch.pm
@@ -382,10 +382,10 @@ sub save
 
     my $summary = $self->summary();
     if (length($summary) > SMT::Utils::PATCH_SUMMARY_SIZE_CHARS) {
-        $summary = substr($summary, 0, SMT::Utils::MYSQL_TEXT_TYPE_SIZE);
+        $summary = substr($summary, 0, SMT::Utils::PATCH_SUMMARY_SIZE_CHARS);
     }
 
-     my $sth = $dbh->prepare($sql);
+    my $sth = $dbh->prepare($sql);
     $sth->bind_param(1, $self->name(), SQL_VARCHAR);
     $sth->bind_param(2, $self->version(), SQL_VARCHAR);
     $sth->bind_param(3, $self->categoryAsInt(), SQL_INTEGER);

--- a/www/perl-lib/SMT/Utils.pm
+++ b/www/perl-lib/SMT/Utils.pm
@@ -62,6 +62,8 @@ use constant TOK2STRING => {
 
 use constant MYSQL_TEXT_TYPE_SIZE => 65535;
 
+use constant PATCH_SUMMARY_SIZE_CHARS => 512;
+
 =head1 NAME
 
 SMT::Utils - Utility library


### PR DESCRIPTION
Fixes https://bugzilla.suse.com/show_bug.cgi?id=1117190
Method taken from https://bugzilla.suse.com/show_bug.cgi?id=1049788