### PR TITLE
Fix not showing all possible offline migration targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME          = smt
-VERSION       = 3.0.42
+VERSION       = 3.0.43
 DESTDIR       = /
 PERL         ?= perl
 PERLMODDIR    = $(shell $(PERL) -MConfig -e 'print $$Config{installvendorlib};')

--- a/package/smt.changes
+++ b/package/smt.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul  9 13:12:08 UTC 2020 - Felix Schnizlein <fschnizlein@suse.com>
+
+- Version 3.0.43
+- Fix missing offline migration targets (bsc#1165012)
+
+-------------------------------------------------------------------
 Fri Jun  7 12:48:08 UTC 2019 - Will Stephenson <wstephenson@suse.com>
 
 - Version 3.0.42

--- a/package/smt.spec
+++ b/package/smt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           smt
-Version:        3.0.42
+Version:        3.0.43
 Release:        0
 Summary:        Subscription Management Tool
 License:        GPL-2.0+

--- a/www/perl-lib/SMT/Utils.pm
+++ b/www/perl-lib/SMT/Utils.pm
@@ -1886,10 +1886,14 @@ sub lookupMigrationTargetsById
     my $log = shift;
     my $vblevel = shift;
 
-    my $query = sprintf("SELECT tgtpdid FROM ProductMigrations WHERE srcpdid = %s AND kind = %s
+    # To match behavior from SCC add all possible online migration targets to
+    # offline migrations
+    my $kind_sql = $migration_kind_sql eq "online" ? "AND kind = 'online'" : "";
+
+    my $query = sprintf("SELECT tgtpdid FROM ProductMigrations WHERE srcpdid = %s %s 
         ORDER BY tgtpdid DESC",
         $dbh->quote($pdid),
-        $dbh->quote($migration_kind_sql)
+        $kind_sql
     );
 
     printLog($log, $vblevel, LOG_DEBUG, "STATEMENT: $query");


### PR DESCRIPTION
When calculating the offline migration targets in SCC, explicit offline
targets as well as all online targets are used.

This behaviour was never introduced to SMT. Add the behaviour to
`lookupMigrationTargetsById` to match the behaviour from SCC.

Belongs to: https://trello.com/c/Mn1IN5FT/1461-bug-1165012-smtmigration-offline-migration-to-sles15sp2-failed-if-registered-against-smt