### PR TITLE
Add two curl options LowSpeedLimit and LowSpeedTime

### DIFF
--- a/config/smt.conf
+++ b/config/smt.conf
@@ -74,6 +74,11 @@ signingKeyID=
 # Configure the Connect Timeout for curl
 #ConnectTimeout = 5
 
+#
+# Abort download if speed is below LowSpeedLimit bytes/sec for LowSpeedTime seconds
+#LowSpeedLimit = 512
+#LowSpeedTime = 120
+
 # Mirroring credentials for this SMT server.
 # These are currently only used to get list of all available repositories
 # from https://your.smt.url/repo/repoindex.xml

--- a/package/smt.changes
+++ b/package/smt.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 30 15:27:01 UTC 2020 - Ali Abdallah <ali.abdallah@suse.com>
+
+- Version 3.0.44
+- Add two options LowSpeedLimit and LowSpeedTime to configure 
+  CURLOPT_LOW_SPEED_LIMIT and CURLOPT_LOW_SPEED_TIME (bsc#1174348)
+
+-------------------------------------------------------------------
 Fri Jul  9 13:12:08 UTC 2020 - Felix Schnizlein <fschnizlein@suse.com>
 
 - Version 3.0.43

--- a/package/smt.spec
+++ b/package/smt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           smt
-Version:        3.0.43
+Version:        3.0.44
 Release:        0
 Summary:        Subscription Management Tool
 License:        GPL-2.0+

--- a/www/perl-lib/SMT/Curl.pm
+++ b/www/perl-lib/SMT/Curl.pm
@@ -68,8 +68,24 @@ sub new
     $self->setopt(CURLOPT_SSLVERSION, 1 ); # 1 should be CURL_SSLVERSION_TLSv1
 
     # Abort download if speed is below 512 bytes/sec for 120 sec, to prevent downloads from getting stuck
-    $self->setopt(CURLOPT_LOW_SPEED_LIMIT, 512 );
-    $self->setopt(CURLOPT_LOW_SPEED_TIME, 120 );
+    # Those values can be configured, by setting 'LowSpeedLimit' and 'LowSpeedTime'
+    if (exists $opt{lowspeedlimit})
+    {
+        $self->setopt(CURLOPT_LOW_SPEED_LIMIT, $opt{lowspeedlimit});
+    }
+    else
+    {
+        $self->setopt(CURLOPT_LOW_SPEED_LIMIT, 512 );
+    }
+
+    if (exists $opt{lowspeedtime})
+    {
+        $self->setopt(CURLOPT_LOW_SPEED_TIME, $opt{lowspeedtime});
+    }
+    else
+    {
+        $self->setopt(CURLOPT_LOW_SPEED_TIME, 120 );
+    }
 
     if(exists $opt{useragent})
     {

--- a/www/perl-lib/SMT/Utils.pm
+++ b/www/perl-lib/SMT/Utils.pm
@@ -1038,6 +1038,8 @@ sub createUserAgent
     if (! exists $opts{connecttimeout})
     {
         $opts{connecttimeout} = int($cfg->val('LOCAL', 'ConnectTimeout', 5));
+        $opts{lowspeedlimit} = int($cfg->val('LOCAL', 'LowSpeedLimit', 512));
+        $opts{lowspeedtime} = int($cfg->val('LOCAL', 'LowSpeedTime', 120));
     }
 
     require SMT::Curl;


### PR DESCRIPTION
Add two options LowSpeedLimit and LowSpeedTime to configure
CURLOPT_LOW_SPEED_LIMIT and CURLOPT_LOW_SPEED_TIME respectively,
see bsc#1174348 for more details.