### PR TITLE
Workaround for products/systems endpoint

### DIFF
--- a/package/smt.changes
+++ b/package/smt.changes
@@ -4,6 +4,7 @@ Fri Jul 30 15:27:01 UTC 2020 - Ali Abdallah <ali.abdallah@suse.com>
 - Version 3.0.44
 - Add two options LowSpeedLimit and LowSpeedTime to configure 
   CURLOPT_LOW_SPEED_LIMIT and CURLOPT_LOW_SPEED_TIME (bsc#1174348)
+- Fix handling dash based version formats in 'systems/products' endpoint (bsc#1165012)
 
 -------------------------------------------------------------------
 Fri Jul  9 13:12:08 UTC 2020 - Felix Schnizlein <fschnizlein@suse.com>

--- a/www/perl-lib/SMT/Utils.pm
+++ b/www/perl-lib/SMT/Utils.pm
@@ -1559,6 +1559,11 @@ sub lookupProductIdByName
 
     my $statement = "SELECT ID, PRODUCTLOWER, VERSIONLOWER, RELLOWER, ARCHLOWER FROM Products where ";
 
+    # Remove .0 or -0 from GA versions (e.g. 15-0)
+    $version =~ s/[\-\.]0$//;
+    # Normalize versions to use . instead of -
+    $version =~ s/-(\d)/\.$1/g;
+
     $statement .= "PRODUCTLOWER = ".$dbh->quote(lc($name));
 
     $statement .= " AND (";


### PR DESCRIPTION
Yast and other applications may send dash based version numbers like '15-3' instead of '15.3' or '15-0' instead of '15'.
By removing superfluous '-0' and replacing '-' with '.' the endpoint is safe to work with dash based version formats.

Please notice: The dash based versions are _not_ supported by SMT. This workaround is only to mitigate recurring issues with the formatting.