### PR TITLE
Fix handling suma 4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME          = smt
-VERSION       = 3.0.45
+VERSION       = 3.0.46
 DESTDIR       = /
 PERL         ?= perl
 PERLMODDIR    = $(shell $(PERL) -MConfig -e 'print $$Config{installvendorlib};')

--- a/package/smt.changes
+++ b/package/smt.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Mar 26 11:01:12 UTC 2021 - Felix Schnizlein <fschnizlein@suse.com>
+- Version 3.0.46
+- Fix wrong migration handling for SUSE Manager 4.0 (bsc#1184130)
+
+-------------------------------------------------------------------
 Wed Sep  9 16:31:34 UTC 2020 - Serhii Kotov <skotov@suse.com>
 - Version 3.0.45
 - Fix patches.description field (bsc#1175871)

--- a/package/smt.spec
+++ b/package/smt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           smt
-Version:        3.0.45
+Version:        3.0.46
 Release:        0
 Summary:        Subscription Management Tool
 License:        GPL-2.0+

--- a/www/perl-lib/SMT/Utils.pm
+++ b/www/perl-lib/SMT/Utils.pm
@@ -1557,9 +1557,40 @@ sub lookupProductIdByName
     my $log = shift;
     my $vblevel = shift;
 
+    # Since SLE 15 there is product naming mismatch requiring SMT
+    # to remove trailing .0 from 15 GA products. We need to make sure
+    # certain products are not affected by the renaming measures.
+    # This list includes products not affected by the .0 naming mismatch.
+    # e.g. SUSE-Manager-Server 4.0 is okay
+    #
+    # See bsc#1184130
+    my @ignoredProducts = ( "CAASP",
+                            "CAP",
+                            "SUSE-Cloud",
+                            "SUSE-Linux-Enterprise-HA-Server",
+                            "SUSE-Linux-Enterprise-RT",
+                            "SUSE-Manager-Proxy",
+                            "SUSE-Manager-Retail-Branch-Server",
+                            "SUSE-Manager-Server",
+                            "SUSE-MicroOS",
+                            "caasp",
+                            "caasp-toolchain",
+                            "longhorn",
+                            "rancher",
+                            "sle-11-WebYaST",
+                            "sle-module-suse-manager-proxy",
+                            "sle-module-suse-manager-retail-branch-server",
+                            "sle-module-suse-manager-server",
+                            "sle-slms",
+                            "sle-slms-1.1-migration",
+                            "sle-studioonsite",
+                            "suse-enterprise-storage"
+    );
+
+
     my $statement = "SELECT ID, PRODUCTLOWER, VERSIONLOWER, RELLOWER, ARCHLOWER FROM Products where ";
 
-    if ($name =~ /sle.*/) {
+    unless (grep $name eq $_ , @ignoredProducts) {
         # Remove .0 or -0 from GA versions (e.g. 15-0)
         $version =~ s/[\-\.]0$//;
         # Normalize versions to use . instead of -

--- a/www/perl-lib/SMT/Utils.pm
+++ b/www/perl-lib/SMT/Utils.pm
@@ -1559,10 +1559,12 @@ sub lookupProductIdByName
 
     my $statement = "SELECT ID, PRODUCTLOWER, VERSIONLOWER, RELLOWER, ARCHLOWER FROM Products where ";
 
-    # Remove .0 or -0 from GA versions (e.g. 15-0)
-    $version =~ s/[\-\.]0$//;
-    # Normalize versions to use . instead of -
-    $version =~ s/-(\d)/\.$1/g;
+    if ($name =~ /sle.*/) {
+        # Remove .0 or -0 from GA versions (e.g. 15-0)
+        $version =~ s/[\-\.]0$//;
+        # Normalize versions to use . instead of -
+        $version =~ s/-(\d)/\.$1/g;
+    }
 
     $statement .= "PRODUCTLOWER = ".$dbh->quote(lc($name));
 


### PR DESCRIPTION
> Only check for misaligned version numbers if the announced product is
SLES based and ignore other possible products.

**card:** https://trello.com/c/h2n7gV03/1905-smt-suma-40-http-error-code-422-no-valid-product-found
**bug:** https://bugzilla.suse.com/show_bug.cgi?id=1184130

## How to test this pull request:

Run a migration from SUSE Manager 4.0 to SUSE Manager 4.1 (online) and check that the migration path is correct.

Get the [migration test client](https://gitlab.suse.de/scc/migration-client) and configure:

```

  ...

  # internal reference SMT host where I installed the this patch
  client.url = '<internal SMT host; reach out to me about the IP>

  # target migration
  client.target_base_product = { "identifier": 'SUSE-Manager-Server', "version": '4.1', "arch": 'x86_64' }

  # installed migration
  client.installed_products = [
    { "identifier": 'SUSE-Manager-Server', "version": '4.0', "arch": 'x86_64'},
  ]

  ...

```
Expected result is a online migration path to 4.1 and no error message: `No valid product found`

** As always if you need help reviewing or have a suggestion please reach out to me! :rocket: **


