### PR TITLE
Add SMT to the User Agent string (bsc#1205451)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME          = smt
-VERSION       = 3.0.46
+VERSION       = 3.0.47
 DESTDIR       = /
 PERL         ?= perl
 PERLMODDIR    = $(shell $(PERL) -MConfig -e 'print $$Config{installvendorlib};')

--- a/package/smt.changes
+++ b/package/smt.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Nov 21 08:01:00 UTC 2022 - José Gómez <jose.gomez@suse.com>
+- Version 3.0.47
+- Fixes SMT does not send version in API headers (bsc#1205451)
+
+-------------------------------------------------------------------
 Mon Mar 26 11:01:12 UTC 2021 - Felix Schnizlein <fschnizlein@suse.com>
 - Version 3.0.46
 - Fix wrong migration handling for SUSE Manager 4.0 (bsc#1184130)

--- a/package/smt.spec
+++ b/package/smt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           smt
-Version:        3.0.46
+Version:        3.0.47
 Release:        0
 Summary:        Subscription Management Tool
 License:        GPL-2.0+

--- a/www/perl-lib/SMT.pm
+++ b/www/perl-lib/SMT.pm
@@ -3,8 +3,9 @@ package SMT;
 use strict;
 use warnings;
 
-use vars qw($SCHEMA_VERSION);
+use vars qw($SCHEMA_VERSION $SMT_VERSION);
 
 $SCHEMA_VERSION = 3.09;
+$SMT_VERSION = '3.0.47';
 
 1;

--- a/www/perl-lib/SMT/Utils.pm
+++ b/www/perl-lib/SMT/Utils.pm
@@ -27,7 +27,7 @@ use Locale::gettext ();
 use POSIX ();     # Needed for setlocale()
 use User::pwent;
 use Sys::GRP;
-
+use WWW::Curl::Easy;
 use SMT::Utils::RequestAgent;
 use JSON;
 
@@ -63,6 +63,8 @@ use constant TOK2STRING => {
 use constant MYSQL_TEXT_TYPE_SIZE => 65535;
 
 use constant PATCH_SUMMARY_SIZE_CHARS => 512;
+
+use constant SMT_USER_AGENT => sprintf("smt/%s %s", $SMT::SMT_VERSION, WWW::Curl::Easy->version());
 
 =head1 NAME
 
@@ -1046,7 +1048,7 @@ sub createUserAgent
 
     my $ua = SMT::Curl->new(%opts);
 
-    my $userAgentString  = $cfg->val('LOCAL', 'UserAgent', WWW::Curl::Easy->version());
+    my $userAgentString  = $cfg->val('LOCAL', 'UserAgent', SMT_USER_AGENT);
     $ua->agent($userAgentString) if( $userAgentString ne "");
 
     return $ua;


### PR DESCRIPTION
When not overwritten by section LOCAL in /etc/smt.conf, SMT user agent will be smt/%version% followed by the output of: `WWW::Curl::Easy->version()`.