### PR TITLE
smt-db always create DB user if it doesn't exist

### DIFF
--- a/db/smt-db
+++ b/db/smt-db
@@ -302,6 +302,8 @@ sub setup
 	return 7;
     }
 
+    $r = $dbh->do("create user if not exists '$smtuser'\@$host");
+
     $r = $dbh->do("grant all on smt.* to '$smtuser'\@$host identified by '$smtpass'");
     $dbh->disconnect;
 


### PR DESCRIPTION
Newer version of mariadb no longer implicitly create db user using grant statement. For that, create db user if it doesn't exist before granting database permission (bsc#1228604).