### PR TITLE
Allow dl.suse.com in SMT to make CDN switch to Akami work

### DIFF
--- a/package/smt.changes
+++ b/package/smt.changes
@@ -4,6 +4,7 @@ Fri Oct 21 13:49:39 UTC 2024 - Adnilson Delgado <adnilson.delgado@suse.com>
 - Version 3.0.50
 - Create db user if it doesn't exist before granting database permission (bsc#1228604)
   - Newer version of mariadb no longer implicitly create db user using grant statement
+- Identify dl.suse.com as SUSE owned host when updating repository information (bsc#1234336)
 
 -------------------------------------------------------------------
 Fri Jul 21 10:10:39 UTC 2023 - José Gómez <jose.gomez@suse.com>

--- a/www/perl-lib/SMT.pm
+++ b/www/perl-lib/SMT.pm
@@ -6,6 +6,6 @@ use warnings;
 use vars qw($SCHEMA_VERSION $SMT_VERSION);
 
 $SCHEMA_VERSION = 3.09;
-$SMT_VERSION = '3.0.49';
+$SMT_VERSION = '3.0.50';
 
 1;

--- a/www/perl-lib/SMT/SCCSync.pm
+++ b/www/perl-lib/SMT/SCCSync.pm
@@ -83,7 +83,7 @@ sub new
     $self->{EXTS} = {};
     $self->{MIGS} = {};
     $self->{TARGET_DONE} = {};
-    $self->{NUHOSTS} = ['nu.novell.com', 'updates.suse.com', 'dl.suse.com', 'dl-ipv4.suse.com'];
+    $self->{NUHOSTS} = ['nu\.novell\.com', '.*\.suse\.com'];
     $self->{LOCALHOST} = "";
     $self->{LOCALSCHEME} = "https";
 
@@ -751,7 +751,8 @@ EOS
     if ($product->{eula_url})
     {
         my $eulaUrl = URI->new($product->{eula_url});
-        if( grep {$_ eq $eulaUrl->host} @{$self->{NUHOSTS}} )
+
+        if( grep {$eulaUrl->host =~ /^$_$/} @{$self->{NUHOSTS}} )
         {
             $eulaUrl->path(SMT::Utils::cleanPath("repo", $eulaUrl->path()));
         }
@@ -1216,7 +1217,7 @@ sub _updateRepositories
     $exthost->fragment(undef);
     $exthost->query(undef);
 
-    if( grep {$_ eq $exthost->host} @{$self->{NUHOSTS}} )
+    if( grep {$exthost->host =~ /^$_$/} @{$self->{NUHOSTS}} )
     {
         $localpath =~ s/^\///;
         if($localpath =~ /^repo\//)
@@ -1607,7 +1608,7 @@ sub _updateProductData
         printLog($self->{LOG}, $self->vblevel(), LOG_ERROR, "Cannot connect to database.");
         return 1;
     }
-    my $nuurl = URI->new($self->{CFG}->val("NU", "NUUrl", "https://updates.suse.com/"));
+    my $nuurl = URI->new($self->{CFG}->val("NU", "NUUrl", "https://dl.suse.com/"));
     push @{$self->{NUHOST}}, $nuurl->host;
     my $localhost = URI->new($self->{CFG}->val("LOCAL", "url"));
     $self->{LOCALHOST} = $localhost->host;

--- a/www/perl-lib/SMT/SCCSync.pm
+++ b/www/perl-lib/SMT/SCCSync.pm
@@ -83,7 +83,7 @@ sub new
     $self->{EXTS} = {};
     $self->{MIGS} = {};
     $self->{TARGET_DONE} = {};
-    $self->{NUHOSTS} = ['nu.novell.com', 'updates.suse.com'];
+    $self->{NUHOSTS} = ['nu.novell.com', 'updates.suse.com', 'dl.suse.com', 'dl-ipv4.suse.com'];
     $self->{LOCALHOST} = "";
     $self->{LOCALSCHEME} = "https";
 


### PR DESCRIPTION
SMT currently does not detect `dl.suse.com` and `dl-ipv4.suse.com` as SUSE owned repositories and automatically disables authentication on these repositories (CATALOGTYPE == 'zypp` instead of 'nu').

To fix this the hosts need to be added to `NUHOSTS`.

**How to test this fix:**
(first, prepare for impact, grab a coffee)

Run a SMT using Vagrant. Here the vagrant file:
```ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|
  config.vm.box = "https://download.suse.de/install/SLE-12-SP5-Vagrant-GM/SLES12-SP5-Vagrant.x86_64-12.5-libvirt-GM.vagrant.libvirt.box"

  regcode = ENV['REGCODE']

  config.vm.network "forwarded_port", guest: 80, host: 8080

  config.vm.provider "libvirt" do |v|
    v.memory = 4048
    v.cpus = 2
    v.driver = "kvm"
    v.storage :file, :size => "150G", :bus => "virtio"
  end

  config.vm.provision "shell", inline: <<-SHELL
      if [ ! -f /etc/zypp/credentials.d/SCCCredentials ]; then
        sudo SUSEConnect -r #{regcode}
      fi
      sudo zypper --non-interactive update
      sudo zypper --non-interactive install -y bc cron vim ca-certificates
      sudo zypper --non-interactive install -y smt SuSEfirewall2 mariadb e2fsprogs yast2-smt

      sudo rcmysql start
      mysqladmin -u root password root
  SHELL

  config.vm.provision "shell", inline: <<-SHELL
    sudo mkfs.ext4 /dev/vdb
    sudo mkdir -p /srv/www/htdocs
    sudo mount /dev/vdb /srv/www/htdocs
    echo '/dev/vdb  /srv/www/htdocs  ext4  defaults  0  2' | sudo tee -a /etc/fstab
  SHELL
end
```
When ready connect via `vagrant ssh` and configure SMT as usual (hint: `sudo yast2 smt-wizard`)

After that you need a glue with https://github.com/SUSE/happy-customer/pull/7982 applied and configuration updated (you need to point glues `default_url_options` towards the address for the host inside your vagrant container. Probably something along the line `192.168.121.1`).

Run glue and update `/etc/smt.conf` to point towards your host.

```
# Update repos, subscriptions etc
# smt-scc-sync

# Enable the 15 SP6 Pool repo (select only x86_64; probably selection 4)
# smt-repos --enable-mirror SLE-Product-SLES15-SP6-Pool

# Mirror the repo
# smt-mirror --repository 6301
# Expect this to work!

# Grab the database data for completeness
$ mysql -u smt -p smt  -e 'SELECT * FROM Catalogs WHERE CATALOGID = 6301'
```

**Now the switchover:**

Update SMT from here: https://download.opensuse.org/repositories/home:/fschnizlein:/branches:/SUSE:/SLE-12-SP1:/Update/SLE_12_SP5/home:fschnizlein:branches:SUSE:SLE-12-SP1:Update.repo 

```
# ON GLUE in a rails console
> repo = Repository.find(6301)
> repo.url = "https://dl.suse.com/SUSE/Products/SLE-Product-SLES/15-SP6/x86_64/product"
> repo.save

# ON SMT
$ smt-scc-sync
$ mysql -u smt -p smt  -e 'SELECT * FROM Catalogs WHERE CATALOGID = 6301'
# expect: Data has changed and especially AUTHTOKEN is updated

$ smt-mirror --repository 6301
# expect: See it working, nothing has been downloaded since we uptodate

# again select the x86_64 repo
$ smt-repos --disable-mirror SLE-Product-SLES15-SP6-Pool
$ smt-repos --delete SLE-Product-SLES15-SP6-Pool
$ smt-repos --enable-mirror SLE-Product-SLES15-SP6-Pool
$ smt-mirror --repository 6301
# expect: It fully mirrors the repository
```

You done it congrats!

Thanks for this review, I know this is not fun