### PR TITLE
Wrong year in the changelog + Missing version bump in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME          = smt
-VERSION       = 3.0.50
+VERSION       = 3.0.51
 DESTDIR       = /
 PERL         ?= perl
 PERLMODDIR    = $(shell $(PERL) -MConfig -e 'print $$Config{installvendorlib};')

--- a/package/smt.changes
+++ b/package/smt.changes
@@ -1,4 +1,4 @@
-Wed Jan 15 13:50 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
+Wed Jan 15 13:50 UTC 2025 - Felix Schnizlein <fschnizlein@suse.com>
 
 - Version 3.0.51
 - Identify dl.suse.com as SUSE owned host when updating repository information (bsc#1234336)


### PR DESCRIPTION
I missed the version bump required in the `Makefile` and accidentally set 2024 instead of 2025 in the Changelog entry

